### PR TITLE
Adds basic workflow implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+architect
+

--- a/cmd/build.go
+++ b/cmd/build.go
@@ -1,0 +1,34 @@
+package cmd
+
+import (
+	"log"
+
+	"github.com/spf13/cobra"
+
+	"github.com/giantswarm/architect/workflow"
+)
+
+var (
+	buildCmd = &cobra.Command{
+		Use:   "build",
+		Short: "build the specified project",
+		Run:   runBuildCmd,
+	}
+
+	dryRun bool
+)
+
+func init() {
+	RootCmd.AddCommand(buildCmd)
+
+	buildCmd.Flags().BoolVar(&dryRun, "dry-run", false, "do not perform any actions")
+}
+
+func runBuildCmd(cmd *cobra.Command, args []string) {
+	executor := workflow.GetExecutor(dryRun)
+
+	build := workflow.NewGolangWorkflow()
+	if err := workflow.RunWorkflow(executor, build); err != nil {
+		log.Fatalln(err)
+	}
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,0 +1,10 @@
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+)
+
+var RootCmd = &cobra.Command{
+	Use:   "architect",
+	Short: "architect is a tool for managing Giant Swarm release engineering",
+}

--- a/main.go
+++ b/main.go
@@ -1,0 +1,13 @@
+package main
+
+import (
+	"log"
+
+	"github.com/giantswarm/architect/cmd"
+)
+
+func main() {
+	if err := cmd.RootCmd.Execute(); err != nil {
+		log.Fatalln(err)
+	}
+}

--- a/workflow/executor.go
+++ b/workflow/executor.go
@@ -1,0 +1,52 @@
+package workflow
+
+import (
+	"log"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+// Executor executes commands.
+type Executor interface {
+	// Run executes the given command, returning any errors.
+	RunCommand(arg ...string) error
+}
+
+// DryRunExecutor does nothing, successfully.
+type DryRunExecutor struct{}
+
+func (e *DryRunExecutor) RunCommand(arg ...string) error {
+	log.Printf("Executing: %v", arg)
+
+	return nil
+}
+
+// ShellExecutor executes commands in a shell.
+type ShellExecutor struct{}
+
+func (e *ShellExecutor) RunCommand(arg ...string) error {
+	command := strings.Join(arg, " ")
+	args := []string{"-c", command}
+
+	log.Printf("Executing: 'bash %v'", args)
+
+	cmd := exec.Command("bash", args...)
+
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+
+	if err := cmd.Run(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func GetExecutor(dryRun bool) Executor {
+	if dryRun {
+		return &DryRunExecutor{}
+	}
+
+	return &ShellExecutor{}
+}

--- a/workflow/gobuild.go
+++ b/workflow/gobuild.go
@@ -1,0 +1,13 @@
+package workflow
+
+// GoBuild runs `go build`.
+type GoBuild struct {
+}
+
+func (t *GoBuild) Run(e Executor) error {
+	if err := e.RunCommand("go", "build", "-a", "-v", "-tags", "netgo"); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/workflow/gotest.go
+++ b/workflow/gotest.go
@@ -1,0 +1,13 @@
+package workflow
+
+// GoTest runs `go test`.
+type GoTest struct {
+}
+
+func (t *GoTest) Run(e Executor) error {
+	if err := e.RunCommand("go", "test", "-v", "$(glide novendor)"); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/workflow/task.go
+++ b/workflow/task.go
@@ -1,0 +1,7 @@
+package workflow
+
+// Task describes a single step in a workflow.
+type Task interface {
+	// Run performs the task, returning any errors.
+	Run(Executor) error
+}

--- a/workflow/workflow.go
+++ b/workflow/workflow.go
@@ -1,0 +1,26 @@
+package workflow
+
+type Workflow struct {
+	Tasks []Task
+}
+
+func NewGolangWorkflow() Workflow {
+	workflow := Workflow{
+		Tasks: []Task{
+			&GoTest{},
+			&GoBuild{},
+		},
+	}
+
+	return workflow
+}
+
+func RunWorkflow(executor Executor, workflow Workflow) error {
+	for _, task := range workflow.Tasks {
+		if err := task.Run(executor); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}


### PR DESCRIPTION
Towards unifying builds, my thinking is to have a simple binary that we ship in an image. This binary will largely replicate what we do in the `circle.yml` currently. We update the `circle.yml` to pull `latest` of the image, and then run it. This lets us update our build process in one place, and the builds will use it automatically.

This is a rough draft of the initial work for that binary. We define a `Workflow`, which is a series of `Tasks`. For example, `go test` and `go build` is one `Workflow`.
We also specify `Executors` to run these `Tasks`, a `DryRunExecutor` and `ShellExecutor` are provided.