### PR TITLE
Adds support for fetching kubernetes certificates from environment

### DIFF
--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -70,6 +70,15 @@ func runDeploy(cmd *cobra.Command, args []string) {
 		log.Fatalf("could not template kubernetes resources: %v\n", err)
 	}
 
+	// When running in CircleCI, we can attempt to grab kubernetes certificates from the environment
+	if kubernetesCaPath == "" && kubernetesCrtPath == "" && kubernetesKeyPath == "" && os.Getenv("CIRCLECI") == "true" {
+		var err error
+		kubernetesCaPath, kubernetesCrtPath, kubernetesKeyPath, err = utils.FetchKubernetesCertsFromEnvironment(workingDirectory)
+		if err != nil {
+			log.Printf("could not load kubernetes certificates from env: %v\n", err)
+		}
+	}
+
 	dockerLogin := commands.Command{
 		Name: "docker-login",
 		Args: []string{

--- a/utils/kubernetes.go
+++ b/utils/kubernetes.go
@@ -1,6 +1,8 @@
 package utils
 
 import (
+	"encoding/base64"
+	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -33,4 +35,42 @@ func TemplateKubernetesResources(kubernetesResourcesDirectoryPath, templatedReso
 	}
 
 	return nil
+}
+
+// FetchKubernetesCertsFromEnvironment attempts to load certificates from the environment
+func FetchKubernetesCertsFromEnvironment(workingDirectory string) (string, string, string, error) {
+	caName := "ca.pem"
+	crtName := "crt.pem"
+	keyName := "key.pem"
+
+	assets := []struct {
+		envVar string
+		name   string
+	}{
+		{envVar: "G8S_CA", name: caName},
+		{envVar: "G8S_CRT", name: crtName},
+		{envVar: "G8S_KEY", name: keyName},
+	}
+
+	for _, asset := range assets {
+		encodedData := os.Getenv(asset.envVar)
+		if encodedData == "" {
+			return "", "", "", fmt.Errorf("could not load certificate data from %v\n", asset.envVar)
+		}
+
+		data, err := base64.StdEncoding.DecodeString(encodedData)
+		if err != nil {
+			return "", "", "", err
+		}
+
+		if err := ioutil.WriteFile(asset.name, data, 0644); err != nil {
+			return "", "", "", err
+		}
+	}
+
+	caPath := filepath.Join(workingDirectory, caName)
+	crtPath := filepath.Join(workingDirectory, crtName)
+	keyPath := filepath.Join(workingDirectory, keyName)
+
+	return caPath, crtPath, keyPath, nil
 }


### PR DESCRIPTION
When running in circle, we currently provide kubernetes
certificates via env vars.
This changeset lets us automatically fetch them,
which makes the circle.yml simpler