### PR TITLE
Modifies build to statically link cgo code

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -72,7 +72,7 @@ func runBuild(cmd *cobra.Command, args []string) {
 			},
 			WorkingDirectory: fmt.Sprintf("/go/src/github.com/%v/%v", organisation, project),
 			Image:            fmt.Sprintf("%v:%v", golangImage, golangVersion),
-			Args:             []string{"go", "build", "-v", "-a", "-tags", "netgo"},
+			Args:             []string{"go", "build", "-v", "-a", "-tags", "netgo", "-ldflags", "-linkmode 'external' -extldflags '-static'"},
 		},
 	)
 


### PR DESCRIPTION
The kubernetes clients use `/x/text/`, which uses cgo.
This changeset links c code statically, so the entire binary is
entirely linked statically