### PR TITLE
Redacts passwords in output

### DIFF
--- a/commands/commands.go
+++ b/commands/commands.go
@@ -38,8 +38,10 @@ func (c Command) String() string {
 
 		if requiresRedaction {
 			parts := strings.Split(arg, "=")
-			parts[1] = "[REDACTED]"
-			arg = parts[0] + "=" + parts[1]
+			if len(parts) == 2 {
+				parts[1] = "[REDACTED]"
+				arg = parts[0] + "=" + parts[1]
+			}
 		}
 
 		redactedArgs = append(redactedArgs, arg)

--- a/commands/commands.go
+++ b/commands/commands.go
@@ -1,6 +1,7 @@
 package commands
 
 import (
+	"fmt"
 	"log"
 	"os"
 	"os/exec"
@@ -18,6 +19,33 @@ type DockerCommandConfig struct {
 type Command struct {
 	Name string
 	Args []string
+}
+
+func (c Command) String() string {
+	redactionPhrases := []string{
+		"password",
+	}
+
+	redactedArgs := []string{}
+	for _, arg := range c.Args {
+		requiresRedaction := false
+
+		for _, redactionPhrase := range redactionPhrases {
+			if strings.Contains(arg, redactionPhrase) {
+				requiresRedaction = true
+			}
+		}
+
+		if requiresRedaction {
+			parts := strings.Split(arg, "=")
+			parts[1] = "[REDACTED]"
+			arg = parts[0] + "=" + parts[1]
+		}
+
+		redactedArgs = append(redactedArgs, arg)
+	}
+
+	return fmt.Sprintf("%s: '%s'", c.Name, strings.Join(redactedArgs, " "))
 }
 
 func NewDockerCommand(name string, config DockerCommandConfig) Command {
@@ -59,8 +87,7 @@ func NewDockerCommand(name string, config DockerCommandConfig) Command {
 func Run(command Command) error {
 	cmd := exec.Command(command.Args[0], command.Args[1:]...)
 
-	log.Printf("running command: %v\n", command.Name)
-	log.Printf("%v\n", strings.Join(cmd.Args, " "))
+	log.Printf("running command: %s\n", command)
 
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr

--- a/commands/commands_test.go
+++ b/commands/commands_test.go
@@ -33,6 +33,13 @@ func TestCommandString(t *testing.T) {
 			},
 			expectedString: "many-pass: 'foo --first-password=[REDACTED] --second-password=[REDACTED]'",
 		},
+		{
+			command: Command{
+				Name: "boolean-flag",
+				Args: []string{"foo", "-password"},
+			},
+			expectedString: "boolean-flag: 'foo -password'",
+		},
 	}
 
 	for index, test := range tests {

--- a/commands/commands_test.go
+++ b/commands/commands_test.go
@@ -1,10 +1,53 @@
 package commands
 
 import (
+	"fmt"
 	"os"
 	"reflect"
 	"testing"
 )
+
+func TestCommandString(t *testing.T) {
+	tests := []struct {
+		command        Command
+		expectedString string
+	}{
+		{
+			command: Command{
+				Name: "docker-run",
+				Args: []string{"docker", "run"},
+			},
+			expectedString: "docker-run: 'docker run'",
+		},
+		{
+			command: Command{
+				Name: "docker-login",
+				Args: []string{"docker", "login", "--email=foo", "--password=bar"},
+			},
+			expectedString: "docker-login: 'docker login --email=foo --password=[REDACTED]'",
+		},
+		{
+			command: Command{
+				Name: "many-pass",
+				Args: []string{"foo", "--first-password=bar", "--second-password=baz"},
+			},
+			expectedString: "many-pass: 'foo --first-password=[REDACTED] --second-password=[REDACTED]'",
+		},
+	}
+
+	for index, test := range tests {
+		returnedString := fmt.Sprintf("%s", test.command)
+
+		if returnedString != test.expectedString {
+			t.Fatalf(
+				"%v: expected string did not match returned\nexpected:\n%s\nreturned: \n%s\n",
+				index,
+				test.expectedString,
+				returnedString,
+			)
+		}
+	}
+}
 
 func TestNewDockerCommand(t *testing.T) {
 	tests := []struct {


### PR DESCRIPTION
Towards https://github.com/giantswarm/architect/issues/16

This changeset adds support for detecting passwords in
task name output, and automatically redacting them.

e.g;
```
2017/03/04 16:12:41 running command: docker-login: 'docker login --email=circleci@giantswarm.io --username=circleci --password=[REDACTED] registry.giantswarm.io'
```