### PR TITLE
Removes docker email from docker login

### DIFF
--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -18,7 +18,6 @@ var (
 		Run:   runDeploy,
 	}
 
-	dockerEmail    string
 	dockerUsername string
 	dockerPassword string
 
@@ -38,17 +37,14 @@ var (
 func init() {
 	RootCmd.AddCommand(deployCmd)
 
-	var defaultDockerEmail string
 	var defaultDockerUsername string
 	var defaultDockerPassword string
 
 	if os.Getenv("CIRCLECI") == "true" {
-		defaultDockerEmail = os.Getenv("DOCKER_EMAIL")
 		defaultDockerUsername = os.Getenv("DOCKER_USERNAME")
 		defaultDockerPassword = os.Getenv("DOCKER_PASSWORD")
 	}
 
-	deployCmd.Flags().StringVar(&dockerEmail, "docker-email", defaultDockerEmail, "email to use to login to docker registry")
 	deployCmd.Flags().StringVar(&dockerUsername, "docker-username", defaultDockerUsername, "username to use to login to docker registry")
 	deployCmd.Flags().StringVar(&dockerPassword, "docker-password", defaultDockerPassword, "password to use to login to docker registry")
 
@@ -84,7 +80,6 @@ func runDeploy(cmd *cobra.Command, args []string) {
 		Args: []string{
 			"docker",
 			"login",
-			fmt.Sprintf("--email=%v", dockerEmail),
 			fmt.Sprintf("--username=%v", dockerUsername),
 			fmt.Sprintf("--password=%v", dockerPassword),
 			registry,


### PR DESCRIPTION
Towards https://github.com/giantswarm/architect/issues/19

The email flag is deprecated in docker, so this changeset
removes it.