### PR TITLE
Adds support to workflow package to deploy to multiple clusters

### DIFF
--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -96,12 +96,16 @@ func runDeploy(cmd *cobra.Command, args []string) {
 		DockerUsername: dockerUsername,
 		DockerPassword: dockerPassword,
 
-		KubernetesApiServer:                       kubernetesApiServer,
-		KubernetesCaPath:                          kubernetesCaPath,
-		KubernetesCrtPath:                         kubernetesCrtPath,
-		KubernetesKeyPath:                         kubernetesKeyPath,
-		KubectlVersion:                            kubectlVersion,
 		KubernetesTemplatedResourcesDirectoryPath: templatedResourcesDirectoryAbsolutePath,
+		KubernetesClusters: []workflow.KubernetesCluster{
+			workflow.KubernetesCluster{
+				ApiServer:      kubernetesApiServer,
+				CaPath:         kubernetesCaPath,
+				CrtPath:        kubernetesCrtPath,
+				KeyPath:        kubernetesKeyPath,
+				KubectlVersion: kubectlVersion,
+			},
+		},
 	}
 
 	workflow, err := workflow.NewDeploy(projectInfo, fs)


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/1300

This provides no new functionality, but prepares the `workflow` package for deploying to multiple clusters (with clusters being an array, instead of a set of strings)

Splitting it up into 2 PRs because this one is already pretty chunky, and I can see wiring the frontend being messy too - I'll do that next.