### PR TITLE
workflow: support dependencies and add go-generate command

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -6,15 +6,15 @@ machine:
         GOOS: "linux"
         GOARCH: "amd64"
         GOPATH: "$HOME/go"
-        GS_WD: "$HOME/go/src/github.com/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME"
+        GS_WD: "$HOME/go/src/github.com/giantswarm/$CIRCLE_PROJECT_REPONAME"
 
 dependencies:
     override:
         - sudo add-apt-repository ppa:masterminds/glide -y
         - sudo apt-get update
         - sudo apt-get install glide -y
-        - mkdir -p $HOME/go/src/github.com/$CIRCLE_PROJECT_USERNAME
-        - cp -rf $HOME/$CIRCLE_PROJECT_REPONAME $HOME/go/src/github.com/$CIRCLE_PROJECT_USERNAME
+        - mkdir -p $HOME/go/src/github.com/giantswarm
+        - cp -rf $HOME/$CIRCLE_PROJECT_REPONAME $HOME/go/src/github.com/giantswarm
 
 test:
     override:

--- a/cmd/build.go
+++ b/cmd/build.go
@@ -22,6 +22,8 @@ var (
 
 	golangImage   string
 	golangVersion string
+
+	dependencies string
 )
 
 func init() {
@@ -32,6 +34,8 @@ func init() {
 
 	buildCmd.Flags().StringVar(&golangImage, "golang-image", "golang", "golang image")
 	buildCmd.Flags().StringVar(&golangVersion, "golang-version", "1.7.5", "golang version")
+
+	buildCmd.Flags().StringVar(&dependencies, "dependencies", "", "space-separated build-time dependencies of your project")
 }
 
 func runBuild(cmd *cobra.Command, args []string) {
@@ -40,6 +44,8 @@ func runBuild(cmd *cobra.Command, args []string) {
 		Organisation:     organisation,
 		Project:          project,
 		Sha:              sha,
+
+		Dependencies: dependencies,
 
 		Registry: registry,
 


### PR DESCRIPTION
Some projects (like the aws-operator) use go generate at build-time.

Adding a step to run "go generate".

Also, adding a "go get" step to get build-time dependencies. These can
be specified in a CLI argument.