### PR TITLE
Adds support for ignoring directories starting with underscore

### DIFF
--- a/utils/glide.go
+++ b/utils/glide.go
@@ -34,7 +34,7 @@ func NoVendor(fs afero.Fs, workingDirectory string) ([]string, error) {
 			if len(parts) <= 1 { // e.g: main.go
 				packageName = "."
 			} else {
-				if parts[0] == "vendor" {
+				if parts[0] == "vendor" || strings.HasPrefix(parts[0], "_") {
 					return nil
 				}
 				packageName = fmt.Sprintf("./%v/...", parts[0])

--- a/utils/glide_test.go
+++ b/utils/glide_test.go
@@ -220,6 +220,23 @@ func TestNoVendor(t *testing.T) {
 			expectedDirectories: []string{},
 		},
 
+		// Test a directory starting with an underscore is ingored
+		{
+			workingDirectory: "/",
+			setUp: func(fs afero.Fs, wd string) error {
+				if err := fs.Mkdir(filepath.Join(wd, "_tests"), directoryPermission); err != nil {
+					return err
+				}
+
+				if _, err := fs.Create(filepath.Join(wd, "_tests", "test.go")); err != nil {
+					return err
+				}
+
+				return nil
+			},
+			expectedDirectories: []string{},
+		},
+
 		// Test two directories, containing golang files, a golang file in the root dir,
 		// and an alternative working directory
 		{


### PR DESCRIPTION
Golang considers directories that begin with an underscore to
not be packages. This behaviour is also present in glide.
This changeset brings the behaviour of architect up to match
glide, by ignoring directories starting with underscores.

See: https://golang.org/pkg/go/build/#Context.Import