### PR TITLE
Add config for services that Happa relies on

### DIFF
--- a/configuration/giantswarm/desmotes/desmotes.go
+++ b/configuration/giantswarm/desmotes/desmotes.go
@@ -1,0 +1,13 @@
+// Package desmotes provides configuration structures for a Desmotes service.
+package desmotes
+
+import (
+	"net/url"
+)
+
+// Desmotes holds configuration for a Desmotes service.
+type Desmotes struct {
+	// Address is the URL to Desmotes.
+	// e.g: 'https://desmotes-g8s.giantswarm.io'
+	Address url.URL
+}

--- a/configuration/giantswarm/giantswarm.go
+++ b/configuration/giantswarm/giantswarm.go
@@ -2,9 +2,13 @@
 package giantswarm
 
 import "github.com/giantswarm/architect/configuration/giantswarm/api"
+import "github.com/giantswarm/architect/configuration/giantswarm/passage"
+import "github.com/giantswarm/architect/configuration/giantswarm/desmotes"
 
 // GiantSwarm holds configuration for GiantSwarm services.
 type GiantSwarm struct {
 	// API holds configuration for the GiantSwarm API.
 	api.API
+	passage.Passage
+	desmotes.Desmotes
 }

--- a/configuration/giantswarm/giantswarm.go
+++ b/configuration/giantswarm/giantswarm.go
@@ -9,6 +9,8 @@ import "github.com/giantswarm/architect/configuration/giantswarm/desmotes"
 type GiantSwarm struct {
 	// API holds configuration for the GiantSwarm API.
 	api.API
+	// Passage holds configuration for Passage.
 	passage.Passage
+	// Desmotes holds configuration for Desmotes.
 	desmotes.Desmotes
 }

--- a/configuration/giantswarm/passage/passage.go
+++ b/configuration/giantswarm/passage/passage.go
@@ -1,0 +1,13 @@
+// Package passage provides configuration structures for a Passage service
+package passage
+
+import (
+	"net/url"
+)
+
+// Passage holds configuration for the a Passage service.
+type Passage struct {
+	// Address is the URL to Passage.
+	// e.g: 'https://passage-g8s.giantswarm.io'
+	Address url.URL
+}

--- a/installation/aws.go
+++ b/installation/aws.go
@@ -12,6 +12,8 @@ import (
 	"github.com/giantswarm/architect/configuration/cluster/kubernetes"
 	"github.com/giantswarm/architect/configuration/giantswarm"
 	"github.com/giantswarm/architect/configuration/giantswarm/api"
+	"github.com/giantswarm/architect/configuration/giantswarm/desmotes"
+	"github.com/giantswarm/architect/configuration/giantswarm/passage"
 	"github.com/giantswarm/architect/configuration/monitoring"
 	"github.com/giantswarm/architect/configuration/monitoring/prometheus"
 	"github.com/giantswarm/architect/configuration/monitoring/testbot"
@@ -39,6 +41,18 @@ var AWS = configuration.Installation{
 				Address: url.URL{
 					Scheme: "https",
 					Host:   "api-aws.giantswarm.io",
+				},
+			},
+			Passage: passage.Passage{
+				Address: url.URL{
+					Scheme: "https",
+					Host:   "passage-aws.giantswarm.io",
+				},
+			},
+			Desmotes: desmotes.Desmotes{
+				Address: url.URL{
+					Scheme: "https",
+					Host:   "desmotes-aws.giantswarm.io",
 				},
 			},
 		},

--- a/installation/leaseweb.go
+++ b/installation/leaseweb.go
@@ -12,6 +12,8 @@ import (
 	"github.com/giantswarm/architect/configuration/cluster/kubernetes"
 	"github.com/giantswarm/architect/configuration/giantswarm"
 	"github.com/giantswarm/architect/configuration/giantswarm/api"
+	"github.com/giantswarm/architect/configuration/giantswarm/desmotes"
+	"github.com/giantswarm/architect/configuration/giantswarm/passage"
 	"github.com/giantswarm/architect/configuration/monitoring"
 	"github.com/giantswarm/architect/configuration/monitoring/prometheus"
 	"github.com/giantswarm/architect/configuration/monitoring/testbot"
@@ -39,6 +41,18 @@ var Leaseweb = configuration.Installation{
 				Address: url.URL{
 					Scheme: "https",
 					Host:   "api-g8s.giantswarm.io",
+				},
+			},
+			Passage: passage.Passage{
+				Address: url.URL{
+					Scheme: "https",
+					Host:   "passage-g8s.giantswarm.io",
+				},
+			},
+			Desmotes: desmotes.Desmotes{
+				Address: url.URL{
+					Scheme: "https",
+					Host:   "desmotes-g8s.giantswarm.io",
 				},
 			},
 		},


### PR DESCRIPTION
We'll need this config per installation. It does make me want to move stuff that passage does more into API, as well as Desmotes. or at least put Passage and Desmotes 'behind' API.

But for now we'd need it. @JosephSalisbury what do you think?