### PR TITLE
Add config structures for Happa

### DIFF
--- a/configuration/giantswarm/giantswarm.go
+++ b/configuration/giantswarm/giantswarm.go
@@ -4,6 +4,7 @@ package giantswarm
 import "github.com/giantswarm/architect/configuration/giantswarm/api"
 import "github.com/giantswarm/architect/configuration/giantswarm/passage"
 import "github.com/giantswarm/architect/configuration/giantswarm/desmotes"
+import "github.com/giantswarm/architect/configuration/giantswarm/happa"
 
 // GiantSwarm holds configuration for GiantSwarm services.
 type GiantSwarm struct {
@@ -13,4 +14,6 @@ type GiantSwarm struct {
 	passage.Passage
 	// Desmotes holds configuration for Desmotes.
 	desmotes.Desmotes
+	// Happa holds configuration for Happa.
+	happa.Happa
 }

--- a/configuration/giantswarm/happa/happa.go
+++ b/configuration/giantswarm/happa/happa.go
@@ -1,0 +1,17 @@
+// Happa package provides configuration structures for a Happa service
+package happa
+
+import (
+	"net/url"
+)
+
+// Happa holds configuration for a Happa service.
+type Happa struct {
+	// Address is the URL to Happa.
+	// e.g: 'https://happa-g8s.giantswarm.io'
+	Address url.URL
+
+	// CreateClusterWorkerType controls the type of form to show when creating a
+	// cluster. Valid values are 'aws' or 'kvm'.
+	CreateClusterWorkerType string
+}

--- a/installation/aws.go
+++ b/installation/aws.go
@@ -13,6 +13,7 @@ import (
 	"github.com/giantswarm/architect/configuration/giantswarm"
 	"github.com/giantswarm/architect/configuration/giantswarm/api"
 	"github.com/giantswarm/architect/configuration/giantswarm/desmotes"
+	"github.com/giantswarm/architect/configuration/giantswarm/happa"
 	"github.com/giantswarm/architect/configuration/giantswarm/passage"
 	"github.com/giantswarm/architect/configuration/monitoring"
 	"github.com/giantswarm/architect/configuration/monitoring/prometheus"
@@ -54,6 +55,13 @@ var AWS = configuration.Installation{
 					Scheme: "https",
 					Host:   "desmotes-aws.giantswarm.io",
 				},
+			},
+			Happa: happa.Happa{
+				Address: url.URL{
+					Scheme: "https",
+					Host:   "happa-aws.giantswarm.io",
+				},
+				CreateClusterWorkerType: "aws",
 			},
 		},
 

--- a/installation/leaseweb.go
+++ b/installation/leaseweb.go
@@ -13,6 +13,7 @@ import (
 	"github.com/giantswarm/architect/configuration/giantswarm"
 	"github.com/giantswarm/architect/configuration/giantswarm/api"
 	"github.com/giantswarm/architect/configuration/giantswarm/desmotes"
+	"github.com/giantswarm/architect/configuration/giantswarm/happa"
 	"github.com/giantswarm/architect/configuration/giantswarm/passage"
 	"github.com/giantswarm/architect/configuration/monitoring"
 	"github.com/giantswarm/architect/configuration/monitoring/prometheus"
@@ -54,6 +55,13 @@ var Leaseweb = configuration.Installation{
 					Scheme: "https",
 					Host:   "desmotes-g8s.giantswarm.io",
 				},
+			},
+			Happa: happa.Happa{
+				Address: url.URL{
+					Scheme: "https",
+					Host:   "happa-g8s.giantswarm.io",
+				},
+				CreateClusterWorkerType: "kvm",
 			},
 		},
 


### PR DESCRIPTION
Similar to https://github.com/giantswarm/architect/pull/49, but now for Happa itself.

Happa's ingress manifest needs to know what domain Happa is on, as does desmotes for proper CORS configuration. 

This then also seems the right place to tell Happa what type of cluster creation form to show the user (the aws or the kvm version).

Once https://github.com/giantswarm/architect/pull/49 is approved and merged, I'll change the base of this PR to `master`