### PR TITLE
Decreases testbot interval to thirty minutes

### DIFF
--- a/installation/aws.go
+++ b/installation/aws.go
@@ -85,7 +85,7 @@ var AWS = configuration.Installation{
 				RetentionPeriod: 2 * 7 * 24 * time.Hour,
 			},
 			Testbot: testbot.Testbot{
-				Interval: 5 * time.Minute,
+				Interval: 30 * time.Minute,
 			},
 		},
 	},


### PR DESCRIPTION
Towards https://github.com/giantswarm/adidas/issues/47

EC2 instances are billed hourly, so a testbot interval of 5 minutes works out to running 12 extra clusters. 30 minutes is 2 clusters, and seems much more reasonable in terms of cost.