### PR TITLE
Changes golang check to file with .go file extension

### DIFF
--- a/workflow/workflow_test.go
+++ b/workflow/workflow_test.go
@@ -106,6 +106,23 @@ func TestGetBuildWorkflow(t *testing.T) {
 			},
 		},
 
+		// Test that a project with a golang file not named `main.go` produces a golang build workflow
+		{
+			setUp: func(fs afero.Fs) error {
+				if _, err := fs.Create(filepath.Join(projectInfo.WorkingDirectory, "other.go")); err != nil {
+					return err
+				}
+
+				return nil
+			},
+			expectedCommandNames: map[int]string{
+				0: GoFmtCommandName,
+				1: GoVetCommandName,
+				2: GoTestCommandName,
+				3: GoBuildCommandName,
+			},
+		},
+
 		// Test a project with only a dockerfile produces a correct workflow
 		{
 			setUp: func(fs afero.Fs) error {


### PR DESCRIPTION
Towards https://github.com/giantswarm/architect/issues/46

We previously checked whether a file named `main.go` existed in
the project. This is not sufficient for libaries, which may not
have a file named `main.go`. This changeset changes the check
for a file with a `.go` suffix, so that libraries will be built.