### PR TITLE
Network host

### DIFF
--- a/commands/commands.go
+++ b/commands/commands.go
@@ -13,6 +13,7 @@ type DockerCommandConfig struct {
 	Env              []string
 	WorkingDirectory string
 	Image            string
+	Net              string
 	Args             []string
 }
 
@@ -72,6 +73,11 @@ func NewDockerCommand(name string, config DockerCommandConfig) Command {
 	}
 
 	args = append(args, "-w", config.WorkingDirectory)
+
+	if config.Net != "" {
+		args = append(args, "--network", config.Net)
+	}
+
 	args = append(args, config.Image)
 
 	for _, arg := range config.Args {

--- a/commands/commands.go
+++ b/commands/commands.go
@@ -13,7 +13,7 @@ type DockerCommandConfig struct {
 	Env              []string
 	WorkingDirectory string
 	Image            string
-	Net              string
+	Network          string
 	Args             []string
 }
 
@@ -74,8 +74,8 @@ func NewDockerCommand(name string, config DockerCommandConfig) Command {
 
 	args = append(args, "-w", config.WorkingDirectory)
 
-	if config.Net != "" {
-		args = append(args, "--network", config.Net)
+	if config.Network != "" {
+		args = append(args, "--network", config.Network)
 	}
 
 	args = append(args, config.Image)

--- a/commands/commands_test.go
+++ b/commands/commands_test.go
@@ -119,7 +119,7 @@ func TestNewDockerCommand(t *testing.T) {
 				Env: []string{
 					"GOOS=linux",
 				},
-				Net:              "host",
+				Network:          "host",
 				WorkingDirectory: "/go/src/github.com/giantswarm/architect",
 				Image:            "golang:1.7.5",
 				Args:             []string{"go", "test", "-v"},

--- a/commands/commands_test.go
+++ b/commands/commands_test.go
@@ -109,6 +109,32 @@ func TestNewDockerCommand(t *testing.T) {
 				"go", "test", "-v",
 			},
 		},
+
+		// Test a similar config, but running in circle
+		{
+			config: DockerCommandConfig{
+				Volumes: []string{
+					"/home/ubuntu/architect:/go/src/github.com/giantswarm/architect",
+				},
+				Env: []string{
+					"GOOS=linux",
+				},
+				Net:              "host",
+				WorkingDirectory: "/go/src/github.com/giantswarm/architect",
+				Image:            "golang:1.7.5",
+				Args:             []string{"go", "test", "-v"},
+			},
+			inCircle: true,
+			expectedArgs: []string{
+				"docker", "run", "--rm=false",
+				"-v", "/home/ubuntu/architect:/go/src/github.com/giantswarm/architect",
+				"-e", "GOOS=linux",
+				"-w", "/go/src/github.com/giantswarm/architect",
+				"--network", "host",
+				"golang:1.7.5",
+				"go", "test", "-v",
+			},
+		},
 	}
 
 	for index, test := range tests {

--- a/workflow/golang.go
+++ b/workflow/golang.go
@@ -147,6 +147,7 @@ func NewGoTestCommand(fs afero.Fs, projectInfo ProjectInfo) (commands.Command, e
 				projectInfo.Organisation,
 				projectInfo.Project,
 			),
+			Net:   "Host",
 			Image: fmt.Sprintf("%v:%v", projectInfo.GolangImage, projectInfo.GolangVersion),
 			Args:  []string{"go", "test", "-v"},
 		},

--- a/workflow/golang.go
+++ b/workflow/golang.go
@@ -147,9 +147,9 @@ func NewGoTestCommand(fs afero.Fs, projectInfo ProjectInfo) (commands.Command, e
 				projectInfo.Organisation,
 				projectInfo.Project,
 			),
-			Net:   "Host",
-			Image: fmt.Sprintf("%v:%v", projectInfo.GolangImage, projectInfo.GolangVersion),
-			Args:  []string{"go", "test", "-v"},
+			Network: "Host",
+			Image:   fmt.Sprintf("%v:%v", projectInfo.GolangImage, projectInfo.GolangVersion),
+			Args:    []string{"go", "test", "-v"},
 		},
 	)
 	goTest.Args = append(goTest.Args, packageArguments...)


### PR DESCRIPTION
In order to do some integration testing, it would be handy if the architect build could reach services that are started up on the host. 

That way we don't have to try and do something more complex like passing in links as part of `architect build`