### PR TITLE
Exits cleanly if no version information

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -7,7 +7,6 @@ dependencies:
     - |
       wget -q $(curl -sS -H "Authorization: token $RELEASE_TOKEN" https://api.github.com/repos/giantswarm/architect/releases/latest | grep browser_download_url | head -n 1 | cut -d '"' -f 4)
     - chmod +x ./architect
-    - ./architect version
 
 test:
   override:

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -25,7 +25,7 @@ func init() {
 func runVersion(cmd *cobra.Command, args []string) {
 	if Commit == "" && BuildTimestamp == "" {
 		fmt.Printf("version information not compiled\n")
-		os.Exit(-1)
+		os.Exit(0)
 	}
 
 	fmt.Printf("Git Commit Hash: %s\n", Commit)


### PR DESCRIPTION
Don't exit with status code 1 if no version information available.

See https://github.com/giantswarm/architect/issues/83 for fixing the (now missing, due to building with architect) build information.