### PR TITLE
add kubectl config

### DIFF
--- a/configuration/guest/guest.go
+++ b/configuration/guest/guest.go
@@ -3,6 +3,7 @@ package guest
 
 import (
 	"github.com/giantswarm/architect/configuration/guest/hyperkube"
+	"github.com/giantswarm/architect/configuration/guest/kubectl"
 	"github.com/giantswarm/architect/configuration/guest/kubernetes"
 )
 
@@ -11,6 +12,10 @@ type Guest struct {
 	// Hyperkube holds configuration for the guest guest cluster's Hyperkube
 	// settings.
 	hyperkube.Hyperkube
+
+	// Kubectl holds configuration for the guest guest cluster's Kubectl
+	// settings.
+	kubectl.Kubectl
 
 	// Kubernetes holds configuration for the guest guest cluster's Kubernetes
 	// installation.

--- a/configuration/guest/kubectl/kubectl.go
+++ b/configuration/guest/kubectl/kubectl.go
@@ -1,0 +1,17 @@
+// Package kubectl provides configuration structures for Kubectl.
+package kubectl
+
+// kind is a private type to ensure only versions defined in this package can
+// be applied to installation configurations. That prevents other packages
+// screwing around with version configurations.
+type kind string
+
+const (
+	Version kind = "1afa480ffb2912fe3605e84fd392c5bd1c9f48b9"
+)
+
+// Kubectl holds configuration for Kubectl settings.
+type Kubectl struct {
+	// Version is the version of Kubectl, e.g. '1afa480ffb2912fe3605e84fd392c5bd1c9f48b9'.
+	Version kind
+}

--- a/configuration/guest/kubectl/kubectl.go
+++ b/configuration/guest/kubectl/kubectl.go
@@ -7,6 +7,7 @@ package kubectl
 type kind string
 
 const (
+	// This image is for kubectl v1.4.7.
 	Version kind = "1afa480ffb2912fe3605e84fd392c5bd1c9f48b9"
 )
 

--- a/installation/aws.go
+++ b/installation/aws.go
@@ -14,6 +14,7 @@ import (
 	"github.com/giantswarm/architect/configuration/giantswarm/passage"
 	"github.com/giantswarm/architect/configuration/guest"
 	"github.com/giantswarm/architect/configuration/guest/hyperkube"
+	"github.com/giantswarm/architect/configuration/guest/kubectl"
 	"github.com/giantswarm/architect/configuration/guest/kubernetes"
 	"github.com/giantswarm/architect/configuration/monitoring"
 	"github.com/giantswarm/architect/configuration/monitoring/prometheus"
@@ -71,6 +72,9 @@ var AWS = configuration.Installation{
 		Guest: guest.Guest{
 			Hyperkube: hyperkube.Hyperkube{
 				Version: hyperkube.Version,
+			},
+			Kubectl: kubectl.Kubectl{
+				Version: kubectl.Version,
 			},
 			Kubernetes: kubernetes.Kubernetes{
 				API: kubernetes.API{

--- a/installation/leaseweb.go
+++ b/installation/leaseweb.go
@@ -14,6 +14,7 @@ import (
 	"github.com/giantswarm/architect/configuration/giantswarm/passage"
 	"github.com/giantswarm/architect/configuration/guest"
 	"github.com/giantswarm/architect/configuration/guest/hyperkube"
+	"github.com/giantswarm/architect/configuration/guest/kubectl"
 	"github.com/giantswarm/architect/configuration/guest/kubernetes"
 	"github.com/giantswarm/architect/configuration/monitoring"
 	"github.com/giantswarm/architect/configuration/monitoring/prometheus"
@@ -68,6 +69,9 @@ var Leaseweb = configuration.Installation{
 		Guest: guest.Guest{
 			Hyperkube: hyperkube.Hyperkube{
 				Version: hyperkube.Version,
+			},
+			Kubectl: kubectl.Kubectl{
+				Version: kubectl.Version,
 			},
 			Kubernetes: kubernetes.Kubernetes{
 				API: kubernetes.API{


### PR DESCRIPTION
With this PR, `architect` sets the version of the kubectl image.

I decided to create a separate package for `kubectl` config. Not sure if it makes more sense to have it within the `kubernetes` package.

Towards  https://github.com/giantswarm/k8scloudconfig/issues/136