### PR TITLE
Set certificate and token TTLs to 6 months

### DIFF
--- a/configuration/auth/vault/vault.go
+++ b/configuration/auth/vault/vault.go
@@ -15,6 +15,9 @@ type Vault struct {
 	// CA is the configuration for Vault CAs.
 	CA
 
+	// Certificate is the configuration for certificates issued by Vault.
+	Certificate
+
 	// Token is the configuration for Vault tokens.
 	Token
 }
@@ -22,6 +25,12 @@ type Vault struct {
 // CA holds configuration for a certificate authority.
 type CA struct {
 	// TTL is the TTL for the CA.
+	TTL time.Duration
+}
+
+// Certificate holds configuration for certificates issued by Vault.
+type Certificate struct {
+	// TTL is the TTL for the certificate.
 	TTL time.Duration
 }
 

--- a/installation/aws.go
+++ b/installation/aws.go
@@ -36,8 +36,11 @@ var AWS = configuration.Installation{
 				CA: vault.CA{
 					TTL: 10 * 365 * 24 * time.Hour,
 				},
+				Certificate: vault.Certificate{
+					TTL: 26 * 7 * 24 * time.Hour,
+				},
 				Token: vault.Token{
-					TTL: 30 * 24 * time.Hour,
+					TTL: 26 * 7 * 24 * time.Hour,
 				},
 			},
 		},

--- a/installation/aws.go
+++ b/installation/aws.go
@@ -37,10 +37,10 @@ var AWS = configuration.Installation{
 					TTL: 10 * 365 * 24 * time.Hour,
 				},
 				Certificate: vault.Certificate{
-					TTL: 26 * 7 * 24 * time.Hour,
+					TTL: 6 * 30 * 24 * time.Hour,
 				},
 				Token: vault.Token{
-					TTL: 26 * 7 * 24 * time.Hour,
+					TTL: 6 * 30 * 24 * time.Hour,
 				},
 			},
 		},

--- a/installation/leaseweb.go
+++ b/installation/leaseweb.go
@@ -33,8 +33,11 @@ var Leaseweb = configuration.Installation{
 				CA: vault.CA{
 					TTL: 10 * 365 * 24 * time.Hour,
 				},
+				Certificate: vault.Certificate{
+					TTL: 26 * 7 * 24 * time.Hour,
+				},
 				Token: vault.Token{
-					TTL: 30 * 24 * time.Hour,
+					TTL: 26 * 7 * 24 * time.Hour,
 				},
 			},
 		},


### PR DESCRIPTION
Towards giantswarm/giantswarm#1504

Until we have automated renewal of certs we want to make them valid for 6 months. This PR adds a Certificate block to Vault and sets both it and the token TTL to 6 months.