### PR TITLE
Adds Route 53 settings to AWS provider

### DIFF
--- a/configuration/provider/aws/aws.go
+++ b/configuration/provider/aws/aws.go
@@ -3,10 +3,13 @@ package aws
 
 import (
 	"github.com/giantswarm/architect/configuration/provider/aws/ec2"
+	"github.com/giantswarm/architect/configuration/provider/aws/route53"
 )
 
 // AWS holds configuration for the AWS provider.
 type AWS struct {
 	// EC2 holds configuration for the EC2 specific settings.
 	ec2.EC2
+	// Route53 holds configuration for the Route53 specific settings.
+	route53.Route53
 }

--- a/configuration/provider/aws/route53/hostedzones/hostedzones.go
+++ b/configuration/provider/aws/route53/hostedzones/hostedzones.go
@@ -1,0 +1,11 @@
+package hostedzones
+
+// HostedZones holds the Hosted Zone IDs for creating guest cluster recordsets.
+type HostedZones struct {
+	// API is the Hosted Zone ID for the API recordset.
+	API string
+	// Etcd is the Hosted Zone ID for the Etcd recordset.
+	Etcd string
+	// Ingress is the Hosted Zone ID for the Ingress recordset.
+	Ingress string
+}

--- a/configuration/provider/aws/route53/route53.go
+++ b/configuration/provider/aws/route53/route53.go
@@ -1,7 +1,7 @@
 package route53
 
 import (
-	"github.com/giantswarm/kubernetesd/flag/service/aws/hostedzones"
+	"github.com/giantswarm/architect/configuration/provider/aws/route53/hostedzones"
 )
 
 // Route53 holds configuration for the Route53 specific settings.

--- a/configuration/provider/aws/route53/route53.go
+++ b/configuration/provider/aws/route53/route53.go
@@ -1,0 +1,12 @@
+package route53
+
+import (
+	"github.com/giantswarm/kubernetesd/flag/service/aws/hostedzones"
+)
+
+// Route53 holds configuration for the Route53 specific settings.
+type Route53 struct {
+	// HostedZones holds the Hosted Zone IDs for creating guest cluster
+	// recordsets.
+	HostedZones hostedzones.HostedZones
+}

--- a/installation/aws.go
+++ b/installation/aws.go
@@ -23,6 +23,8 @@ import (
 	"github.com/giantswarm/architect/configuration/provider/aws"
 	"github.com/giantswarm/architect/configuration/provider/aws/ec2"
 	"github.com/giantswarm/architect/configuration/provider/aws/ec2/instance"
+	"github.com/giantswarm/architect/configuration/provider/aws/route53"
+	"github.com/giantswarm/kubernetesd/flag/service/aws/hostedzones"
 )
 
 var AWS = configuration.Installation{
@@ -116,6 +118,13 @@ var AWS = configuration.Installation{
 						Available:    instance.Available(),
 						Capabilities: instance.Capabilities(),
 						Default:      instance.Default,
+					},
+				},
+				Route53: route53.Route53{
+					HostedZones: hostedzones.HostedZones{
+						API:     "Z1Z5J7V0K6UO20",
+						Etcd:    "Z1Z5J7V0K6UO20",
+						Ingress: "Z33IHCRH5W883L",
 					},
 				},
 			},

--- a/installation/aws.go
+++ b/installation/aws.go
@@ -24,7 +24,7 @@ import (
 	"github.com/giantswarm/architect/configuration/provider/aws/ec2"
 	"github.com/giantswarm/architect/configuration/provider/aws/ec2/instance"
 	"github.com/giantswarm/architect/configuration/provider/aws/route53"
-	"github.com/giantswarm/kubernetesd/flag/service/aws/hostedzones"
+	"github.com/giantswarm/architect/configuration/provider/aws/route53/hostedzones"
 )
 
 var AWS = configuration.Installation{


### PR DESCRIPTION
Towards giantswarm/giantswarm#1501

Adds Route53 section to the AWS provider and sets values for the hosted zones. This is because creating hosted zones should be part of installation setup.