### PR TITLE
Add configurable intercom app id, and set it for aws and leaseweb installations

### DIFF
--- a/configuration/giantswarm/happa/happa.go
+++ b/configuration/giantswarm/happa/happa.go
@@ -10,4 +10,8 @@ type Happa struct {
 	// Address is the URL to Happa.
 	// e.g: 'https://happa-g8s.giantswarm.io'
 	Address url.URL
+
+	// IntercomAppID is the App ID for intercom.
+	// e.g.: bdvx0cb8
+	IntercomAppID string
 }

--- a/installation/aws.go
+++ b/installation/aws.go
@@ -71,6 +71,7 @@ var AWS = configuration.Installation{
 					Scheme: "https",
 					Host:   "happa-aws.giantswarm.io",
 				},
+				IntercomAppID: "ictssdcu",
 			},
 		},
 

--- a/installation/leaseweb.go
+++ b/installation/leaseweb.go
@@ -66,6 +66,7 @@ var Leaseweb = configuration.Installation{
 					Scheme: "https",
 					Host:   "happa-g8s.giantswarm.io",
 				},
+				IntercomAppID: "ictssdcu",
 			},
 		},
 


### PR DESCRIPTION
Related to: https://github.com/giantswarm/happa/issues/158