### PR TITLE
Fix codename for viking installation

### DIFF
--- a/events/events.go
+++ b/events/events.go
@@ -35,7 +35,7 @@ var environmentProjects = map[Environment][]string{
 		"tokend",
 		"userd",
 	},
-	"vikings": []string{
+	"viking": []string{
 		"api",
 		"cert-operator",
 		"cluster-service",


### PR DESCRIPTION
This should've been `viking` and not `vikings`