### PR TITLE
customizable-networks

### DIFF
--- a/configuration/guest/calico/calico.go
+++ b/configuration/guest/calico/calico.go
@@ -1,0 +1,11 @@
+package calico // Package calico provides configuration structures for Calico.
+
+// Calico holds configuration for guest cluster calico settings.
+type Calico struct {
+	// subnet for calico
+	// ie 192.168.0.0
+	Subnet string
+	// cidr for calico sibnets
+	// ie 16
+	CIDR string
+}

--- a/configuration/guest/calico/calico.go
+++ b/configuration/guest/calico/calico.go
@@ -2,10 +2,8 @@ package calico // Package calico provides configuration structures for Calico.
 
 // Calico holds configuration for guest cluster calico settings.
 type Calico struct {
-	// subnet for calico
-	// ie 192.168.0.0
+	// Subnet for calico, eg. 192.168.0.0.
 	Subnet string
-	// cidr for calico sibnets
-	// ie 16
+	// Cidr for calico subnets, eg. 16.
 	CIDR string
 }

--- a/configuration/guest/calico/calico.go
+++ b/configuration/guest/calico/calico.go
@@ -4,6 +4,6 @@ package calico // Package calico provides configuration structures for Calico.
 type Calico struct {
 	// Subnet for calico, eg. 192.168.0.0.
 	Subnet string
-	// Cidr for calico subnets, eg. 16.
+	// CIDR for calico subnets, eg. 16.
 	CIDR string
 }

--- a/configuration/guest/guest.go
+++ b/configuration/guest/guest.go
@@ -2,6 +2,7 @@
 package guest
 
 import (
+	"github.com/giantswarm/architect/configuration/guest/calico"
 	"github.com/giantswarm/architect/configuration/guest/hyperkube"
 	"github.com/giantswarm/architect/configuration/guest/kubectl"
 	"github.com/giantswarm/architect/configuration/guest/kubernetes"
@@ -20,4 +21,7 @@ type Guest struct {
 	// Kubernetes holds configuration for the guest guest cluster's Kubernetes
 	// installation.
 	kubernetes.Kubernetes
+
+	// Calico holds configuration for calico in guest cluster.
+	calico.Calico
 }

--- a/configuration/provider/kvm/flannel/flannel.go
+++ b/configuration/provider/kvm/flannel/flannel.go
@@ -1,7 +1,10 @@
 package flannel
 
 type Flannel struct {
-	VNIRange Range
+	VNIRange       Range
+	NetworkFormat  string
+	Interface      string
+	PrivateNetwork string
 }
 
 type Range struct {

--- a/installation/leaseweb.go
+++ b/installation/leaseweb.go
@@ -14,6 +14,7 @@ import (
 	"github.com/giantswarm/architect/configuration/giantswarm/happa"
 	"github.com/giantswarm/architect/configuration/giantswarm/passage"
 	"github.com/giantswarm/architect/configuration/guest"
+	"github.com/giantswarm/architect/configuration/guest/calico"
 	"github.com/giantswarm/architect/configuration/guest/hyperkube"
 	"github.com/giantswarm/architect/configuration/guest/kubectl"
 	"github.com/giantswarm/architect/configuration/guest/kubernetes"
@@ -90,6 +91,10 @@ var Leaseweb = configuration.Installation{
 					BaseDomain: "gigantic.io",
 				},
 			},
+			Calico: calico.Calico{
+				Subnet: "192.168.0.0",
+				CIDR:   "16",
+			},
 		},
 
 		Monitoring: monitoring.Monitoring{
@@ -118,6 +123,9 @@ var Leaseweb = configuration.Installation{
 						Min: 2,
 						Max: 210,
 					},
+					Interface:      "bond0.3",
+					NetworkFormat:  "10.%d.0.0",
+					PrivateNetwork: "10.0.4.0/24",
 				},
 				Ingress: ingress.Ingress{
 					PortRange: ingress.PortRange{


### PR DESCRIPTION
changes to address customized networks for `kubernetesd` https://github.com/giantswarm/kubernetesd/pull/205 and https://github.com/giantswarm/installations/pull/5