### PR TITLE
Adds support for Helm templating in deployment.yaml and Chart.yaml

### DIFF
--- a/template/error.go
+++ b/template/error.go
@@ -52,3 +52,17 @@ var emptyKubernetesResourcesDirectoryPath = errgo.New("empty kubernetes resource
 func IsEmptyKubernetesResourcesDirectoryPath(err error) bool {
 	return errgo.Cause(err) == emptyKubernetesResourcesDirectoryPath
 }
+
+var nilTemplateStructError = errgo.New("nil template struct")
+
+// IsNilTemplateStruct asserts nilTemplateStruct.
+func IsNilTemplateStruct(err error) bool {
+	return errgo.Cause(err) == nilTemplateStructError
+}
+
+var notStringTypeError = errgo.New("not string type")
+
+// IsNotStringType asserts notStringTypeError.
+func IsNotStringType(err error) bool {
+	return errgo.Cause(err) == notStringTypeError
+}

--- a/template/helm.go
+++ b/template/helm.go
@@ -59,20 +59,23 @@ func (t TemplateHelmChartTask) Run() error {
 	for _, path := range paths {
 		exists, err := afero.Exists(t.fs, path)
 		if err != nil {
-			microerror.MaskAny(err)
+			return microerror.MaskAny(err)
 		}
 
 		if exists {
 			contents, err := afero.ReadFile(t.fs, path)
 			if err != nil {
-				microerror.MaskAny(err)
+				return microerror.MaskAny(err)
 			}
 
 			buildInfo := BuildInfo{SHA: t.sha}
 			templatedContents, err := SafeTemplate(buildInfo, contents)
+			if err != nil {
+				return microerror.MaskAny(err)
+			}
 
 			if err := afero.WriteFile(t.fs, path, templatedContents, permission); err != nil {
-				microerror.MaskAny(err)
+				return microerror.MaskAny(err)
 			}
 		}
 	}

--- a/template/helm.go
+++ b/template/helm.go
@@ -1,9 +1,7 @@
 package template
 
 import (
-	"bytes"
 	"fmt"
-	"html/template"
 	"path/filepath"
 
 	"github.com/spf13/afero"
@@ -71,18 +69,9 @@ func (t TemplateHelmChartTask) Run() error {
 			}
 
 			buildInfo := BuildInfo{SHA: t.sha}
+			templatedContents, err := SafeTemplate(buildInfo, contents)
 
-			newTemplate := template.Must(template.New(path).Parse(string(contents)))
-			if err != nil {
-				microerror.MaskAny(err)
-			}
-
-			var buf bytes.Buffer
-			if err := newTemplate.Execute(&buf, buildInfo); err != nil {
-				microerror.MaskAny(err)
-			}
-
-			if err := afero.WriteFile(t.fs, path, buf.Bytes(), permission); err != nil {
+			if err := afero.WriteFile(t.fs, path, templatedContents, permission); err != nil {
 				microerror.MaskAny(err)
 			}
 		}

--- a/template/safe.go
+++ b/template/safe.go
@@ -16,7 +16,7 @@ const (
 	StringTypeName = "string"
 )
 
-// safeTemplate takes a struct and a template byte array, and attempts to
+// SafeTemplate takes a struct and a template byte array, and attempts to
 // safely template the byte array.
 // 'Safely' is defined as only templating fields of the format:
 // `{{ .X }}`, where X is the name of some field in the supplied struct,

--- a/template/safe.go
+++ b/template/safe.go
@@ -1,0 +1,52 @@
+package template
+
+import (
+	"fmt"
+	"reflect"
+	"strings"
+
+	microerror "github.com/giantswarm/microkit/error"
+)
+
+const (
+	// TemplateFieldFormat is the format for fields that SafeTemplate will template.
+	TemplateFieldFormat = "{{ .%s }}"
+
+	// StringTypeName is the name of the string type.
+	StringTypeName = "string"
+)
+
+// safeTemplate takes a struct and a template byte array, and attempts to
+// safely template the byte array.
+// 'Safely' is defined as only templating fields of the format:
+// `{{ .X }}`, where X is the name of some field in the supplied struct,
+// and not smashing any other templating strings.
+func SafeTemplate(s interface{}, template []byte) ([]byte, error) {
+	if s == nil {
+		return nil, microerror.MaskAny(nilTemplateStructError)
+	}
+
+	stringsToReplace := map[string]string{}
+
+	v := reflect.ValueOf(s)
+
+	for i := 0; i < v.NumField(); i++ {
+		name := v.Type().Field(i).Name
+		value := v.FieldByName(name).String()
+
+		typeName := v.Type().Field(i).Type.Name()
+		if typeName != StringTypeName {
+			return nil, microerror.MaskAnyf(notStringTypeError, "name: %v, type: %v", name, typeName)
+		}
+
+		stringsToReplace[name] = value
+	}
+
+	templateString := string(template)
+	for name, value := range stringsToReplace {
+		stringToReplace := fmt.Sprintf(TemplateFieldFormat, name)
+		templateString = strings.Replace(templateString, stringToReplace, value, -1)
+	}
+
+	return []byte(templateString), nil
+}

--- a/template/safe_test.go
+++ b/template/safe_test.go
@@ -1,0 +1,93 @@
+package template
+
+import "testing"
+
+// TestSafeTemplate tests the SafeTemplate function.
+func TestSafeTemplate(t *testing.T) {
+	tests := []struct {
+		s                    interface{}
+		template             string
+		expectedContent      string
+		expectedErrorMatcher func(error) bool
+	}{
+		// Test that a nil struct and empty string is templated correctly.
+		{
+			s:                    nil,
+			template:             "",
+			expectedContent:      "",
+			expectedErrorMatcher: IsNilTemplateStruct,
+		},
+
+		// Test a template with an int field.
+		{
+			s: struct {
+				foo int
+			}{
+				foo: 10,
+			},
+			template:             "{{ .foo }}",
+			expectedContent:      "",
+			expectedErrorMatcher: IsNotStringType,
+		},
+
+		// Test an empty struct and string is templated correctly.
+		{
+			s:                    struct{}{},
+			template:             "",
+			expectedContent:      "",
+			expectedErrorMatcher: nil,
+		},
+
+		// Test a struct with private fields is templated correctly.
+		{
+			s: struct {
+				private string
+			}{
+				private: "you-cant-see-me",
+			},
+			template:             "{{ .private }}",
+			expectedContent:      "you-cant-see-me",
+			expectedErrorMatcher: nil,
+		},
+
+		// Test a template with multiple fields.
+		{
+			s: struct {
+				sha string
+			}{
+				sha: "foo",
+			},
+			template:             "{{ .sha }} {{ .sha }}",
+			expectedContent:      "foo foo",
+			expectedErrorMatcher: nil,
+		},
+	}
+
+	for index, test := range tests {
+		returnedContent, err := SafeTemplate(test.s, []byte(test.template))
+
+		// An error was returned, we expected one, and it's the right one, continue.
+		if err != nil && test.expectedErrorMatcher != nil && test.expectedErrorMatcher(err) {
+			continue
+		}
+		// An error was returned, but we did not expect one, fail.
+		if err != nil && test.expectedErrorMatcher == nil {
+			t.Fatalf("%v: unexpected error during templating: %v\n", index, err)
+		}
+		// An error was not returned, but we expected one, fail.
+		if err == nil && test.expectedErrorMatcher != nil {
+			t.Fatalf("%v: did not receive expected error\n", index)
+		}
+
+		returnedContentString := string(returnedContent)
+
+		if returnedContentString != test.expectedContent {
+			t.Fatalf(
+				"%v: returned content did not match expected content:\nreturned: %v\nexpected: %v\n",
+				index,
+				returnedContentString,
+				test.expectedContent,
+			)
+		}
+	}
+}


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/1655

We require support for templating deployment.yaml files with the
latest image tag, as well as having Helm templating inside these
files - see https://github.com/giantswarm/api/pull/420

This introduces a method that the architect templating uses, which
allows for templating the BuildInfo struct, without clobbering the
Helm templating, as well as being open to new fields in the future.