### PR TITLE
Changes architect templating to use square brackets for delim

### DIFF
--- a/template/helm.go
+++ b/template/helm.go
@@ -72,7 +72,7 @@ func (t TemplateHelmChartTask) Run() error {
 
 			buildInfo := BuildInfo{SHA: t.sha}
 
-			newTemplate := template.Must(template.New(path).Parse(string(contents)))
+			newTemplate := template.Must(template.New(path).Delims("[[", "]]").Parse(string(contents)))
 			if err != nil {
 				microerror.MaskAny(err)
 			}

--- a/template/helm_test.go
+++ b/template/helm_test.go
@@ -65,11 +65,11 @@ func TestTemplateHelmChartTask(t *testing.T) {
 				}{
 					{
 						path: filepath.Join(helmPath, "test-chart", HelmChartYamlName),
-						data: "version: 1.0.0-{{ .SHA }}",
+						data: "version: 1.0.0-[[ .SHA ]]",
 					},
 					{
 						path: filepath.Join(helmPath, "test-chart", HelmTemplateDirectoryName, HelmDeploymentYamlName),
-						data: "image: {{ .SHA }}",
+						data: "image: [[ .SHA ]] foo: {{ .Values.Foo }}",
 					},
 					{
 						path: filepath.Join(helmPath, "test-chart", HelmTemplateDirectoryName, "ingress.yaml"),
@@ -96,7 +96,7 @@ func TestTemplateHelmChartTask(t *testing.T) {
 					},
 					{
 						path: filepath.Join(helmPath, "test-chart", HelmTemplateDirectoryName, HelmDeploymentYamlName),
-						data: "image: jabberwocky",
+						data: "image: jabberwocky foo: {{ .Values.Foo }}",
 					},
 					{
 						path: filepath.Join(helmPath, "test-chart", HelmTemplateDirectoryName, "ingress.yaml"),


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/1655

We need to support templating values in files that include
Helm templating.
Moving to use square brackets for delimeters for the architect
templating means that we don't clobber the helm templating,
and that there's a better distinction between the templating phases.