### PR TITLE
Add ingress controller version to the guest provider

### DIFF
--- a/configuration/guest/guest.go
+++ b/configuration/guest/guest.go
@@ -4,6 +4,7 @@ package guest
 import (
 	"github.com/giantswarm/architect/configuration/guest/calico"
 	"github.com/giantswarm/architect/configuration/guest/hyperkube"
+	"github.com/giantswarm/architect/configuration/guest/ingress"
 	"github.com/giantswarm/architect/configuration/guest/kubectl"
 	"github.com/giantswarm/architect/configuration/guest/kubernetes"
 )
@@ -13,6 +14,10 @@ type Guest struct {
 	// Hyperkube holds configuration for the guest guest cluster's Hyperkube
 	// settings.
 	hyperkube.Hyperkube
+
+	// IngressController holds configuration for the guest guest cluster's
+	// Ingress Controller settings.
+	ingress.IngressController
 
 	// Kubectl holds configuration for the guest guest cluster's Kubectl
 	// settings.

--- a/configuration/guest/ingress/ingress_controller.go
+++ b/configuration/guest/ingress/ingress_controller.go
@@ -1,0 +1,17 @@
+// Package ingress provides configuration structures for the Ingress Controller.
+package ingress
+
+// kind is a private type to ensure only versions defined in this package can
+// be applied to installation configurations. That prevents other packages
+// screwing around with version configurations.
+type kind string
+
+const (
+	Version kind = "0.9.0-beta.11"
+)
+
+// IngressController holds configuration for Ingress Controller settings.
+type IngressController struct {
+	// Version is the version of Ingress Controller, e.g. '0.9.0-beta.11'.
+	Version kind
+}


### PR DESCRIPTION
Towards giantswarm/giantswarm#1695

This PR adds the version of the Ingress Controller docker image to the guest provider. This is so we use a retagged image and can replace the hardcoded image in `k8scloudconfig`.