### PR TITLE
promote chart to stable channel on deploy

### DIFF
--- a/workflow/workflow.go
+++ b/workflow/workflow.go
@@ -247,11 +247,14 @@ func NewDeploy(projectInfo ProjectInfo, fs afero.Fs) (Workflow, error) {
 			}
 			w = append(w, helmLogin)
 
-			helmPushToChannel, err := NewHelmPromoteToStableChannelTask(fs, projectInfo)
+			helmPromoteToChannel, err := NewHelmPromoteToStableChannelTask(fs, projectInfo)
 			if err != nil {
 				return nil, microerror.Mask(err)
 			}
-			w = append(w, helmPushToChannel)
+
+			wrappedHelmPromoteToChannel := tasks.NewRetryTask(backoff.NewExponentialBackOff(), helmPromoteToChannel)
+
+			w = append(w, wrappedHelmPromoteToChannel)
 		}
 
 	}

--- a/workflow/workflow.go
+++ b/workflow/workflow.go
@@ -219,6 +219,41 @@ func NewDeploy(projectInfo ProjectInfo, fs afero.Fs) (Workflow, error) {
 			wrappedDockerPushLatest := tasks.NewRetryTask(backoff.NewExponentialBackOff(), dockerPushLatest)
 			w = append(w, wrappedDockerPushLatest)
 		}
+
+		helmDirectoryExists, err := afero.Exists(fs, filepath.Join(projectInfo.WorkingDirectory, "helm"))
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+		if helmDirectoryExists {
+			{
+				helmPull, err := NewHelmPullTask(fs, projectInfo)
+				if err != nil {
+					return nil, microerror.Mask(err)
+				}
+				wrappedHelmPull := tasks.NewRetryTask(backoff.NewExponentialBackOff(), helmPull)
+
+				w = append(w, wrappedHelmPull)
+			}
+
+			helmChartTemplate, err := NewTemplateHelmChartTask(fs, projectInfo)
+			if err != nil {
+				return nil, microerror.Mask(err)
+			}
+			w = append(w, helmChartTemplate)
+
+			helmLogin, err := NewHelmLoginTask(fs, projectInfo)
+			if err != nil {
+				return nil, microerror.Mask(err)
+			}
+			w = append(w, helmLogin)
+
+			helmPushToChannel, err := NewHelmPromoteToStableChannelTask(fs, projectInfo)
+			if err != nil {
+				return nil, microerror.Mask(err)
+			}
+			w = append(w, helmPushToChannel)
+		}
+
 	}
 
 	return w, nil


### PR DESCRIPTION
These changes add the just built chart to the `stable` channel on deploy, this will allow us to reference and use the charts currently deployed from CI setups.

In order to make unit tests happy the promotion to stable is only done when a dockerfile is in place. Also the promotion task is bound to the stable channel, imo we don't need to parameterize the channel, let me know wdyt.