### PR TITLE
Remove html template import

### DIFF
--- a/template/helm.go
+++ b/template/helm.go
@@ -3,9 +3,9 @@ package template
 import (
 	"bytes"
 	"fmt"
-	"html/template"
 	"os"
 	"path/filepath"
+	"text/template"
 
 	"github.com/spf13/afero"
 

--- a/template/helm_test.go
+++ b/template/helm_test.go
@@ -76,6 +76,10 @@ func TestTemplateHelmChartTask(t *testing.T) {
 						data: "image: [[ .SHA ]] foo: {{ .Values.Foo }}",
 					},
 					{
+						path: filepath.Join(helmPath, "test-chart", HelmTemplateDirectoryName, "otherfile.yaml"),
+						data: "image: [[ .SHA ]] foo: < abc",
+					},
+					{
 						path: filepath.Join(helmPath, "test-chart", HelmTemplateDirectoryName, "subdirectory", "replicaset.yaml"),
 						data: "image: [[ .SHA ]] foo: {{ .Values.Foo }}",
 					},
@@ -109,6 +113,10 @@ func TestTemplateHelmChartTask(t *testing.T) {
 					{
 						path: filepath.Join(helmPath, "test-chart", HelmTemplateDirectoryName, "daemonset.yaml"),
 						data: "image: jabberwocky foo: {{ .Values.Foo }}",
+					},
+					{
+						path: filepath.Join(helmPath, "test-chart", HelmTemplateDirectoryName, "otherfile.yaml"),
+						data: "image: jabberwocky foo: < abc",
 					},
 					{
 						path: filepath.Join(helmPath, "test-chart", HelmTemplateDirectoryName, "subdirectory", "replicaset.yaml"),


### PR DESCRIPTION
After the recent issues with go escaping `<` in our rules.