### PR TITLE
do not push empty channels

### DIFF
--- a/workflow/error.go
+++ b/workflow/error.go
@@ -32,6 +32,13 @@ func IsIncorrectNumberCerts(err error) bool {
 	return microerror.Cause(err) == incorrectNumberCertsError
 }
 
+var emptyChannelError = microerror.New("empty channel")
+
+// IsEmptyChannel asserts emptyChannelError
+func IsEmptyChannel(err error) bool {
+	return microerror.Cause(err) == emptyChannelError
+}
+
 var emptyWorkingDirectoryError = microerror.New("empty working directory")
 
 // IsEmptyWorkingDirectory asserts emptyWorkingDirectoryError

--- a/workflow/workflow.go
+++ b/workflow/workflow.go
@@ -300,7 +300,7 @@ func NewPublish(projectInfo ProjectInfo, fs afero.Fs) (Workflow, error) {
 	if chartDirectoryExists {
 		for _, c := range projectInfo.Channels {
 			if c == "" {
-				continue
+				return nil, microerror.Mask(emptyChannelError)
 			}
 			helmPromoteToChannel, err := NewHelmPromoteToChannelTask(fs, chartDirectory, projectInfo, c)
 			if err != nil {

--- a/workflow/workflow.go
+++ b/workflow/workflow.go
@@ -299,6 +299,9 @@ func NewPublish(projectInfo ProjectInfo, fs afero.Fs) (Workflow, error) {
 
 	if chartDirectoryExists {
 		for _, c := range projectInfo.Channels {
+			if c == "" {
+				continue
+			}
 			helmPromoteToChannel, err := NewHelmPromoteToChannelTask(fs, chartDirectory, projectInfo, c)
 			if err != nil {
 				return nil, microerror.Mask(err)

--- a/workflow/workflow_test.go
+++ b/workflow/workflow_test.go
@@ -523,6 +523,15 @@ func TestGetPublishWorkflow(t *testing.T) {
 				fmt.Sprintf("%s-unstable", HelmPushTaskName),
 			},
 		},
+		{
+			description: "do not push empty channels",
+			channels:    []string{"alpha", "beta", "", "unstable", ""},
+			expectedTaskNames: []string{
+				fmt.Sprintf("%s-alpha", HelmPushTaskName),
+				fmt.Sprintf("%s-beta", HelmPushTaskName),
+				fmt.Sprintf("%s-unstable", HelmPushTaskName),
+			},
+		},
 	}
 
 	for _, tc := range tcs {


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/1902

Prevents trying to push an empty string as channel name.