### PR TITLE
Add concurrent tasks and run go tasks concurrently

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -78,6 +78,12 @@
   revision = "9a379c6b3e95a790ffc43293c2a78dee0d7b6e20"
 
 [[projects]]
+  branch = "master"
+  name = "golang.org/x/sync"
+  packages = ["errgroup"]
+  revision = "fd80eb99c8f653c847d294a001bdf2a3a6f768f5"
+
+[[projects]]
   name = "golang.org/x/text"
   packages = [
     "internal/gen",
@@ -111,6 +117,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "732432ee655f87bed1727480c6ac929c27f13031eedba05a61c03caf5199867c"
+  inputs-digest = "d401fc834bf48044c51aa1339cdec453691f1cc07b6fe3a88b5fd4dcd253547f"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -40,3 +40,7 @@
 [prune]
   go-tests = true
   unused-packages = true
+
+[[constraint]]
+  branch = "master"
+  name = "golang.org/x/sync"

--- a/tasks/concurrent.go
+++ b/tasks/concurrent.go
@@ -1,0 +1,51 @@
+package tasks
+
+import (
+	"bytes"
+
+	"github.com/giantswarm/microerror"
+	"golang.org/x/sync/errgroup"
+)
+
+type ConcurrentTask struct {
+	name  string
+	tasks []Task
+}
+
+func (c *ConcurrentTask) Run() error {
+	var g errgroup.Group
+
+	for _, t := range c.tasks {
+		g.Go(t.Run)
+	}
+
+	err := g.Wait()
+
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	return nil
+}
+
+func (c *ConcurrentTask) Name() string {
+	return c.String()
+}
+
+func (c *ConcurrentTask) String() string {
+	var buffer bytes.Buffer
+
+	for _, t := range c.tasks {
+		buffer.WriteString(t.Name())
+		buffer.WriteString(";")
+	}
+
+	return buffer.String()
+}
+
+func NewConcurrentTask(name string, tasks ...Task) *ConcurrentTask {
+	return &ConcurrentTask{
+		name:  name,
+		tasks: tasks,
+	}
+}

--- a/tasks/concurrent.go
+++ b/tasks/concurrent.go
@@ -12,6 +12,13 @@ type ConcurrentTask struct {
 	tasks []Task
 }
 
+func NewConcurrentTask(name string, tasks ...Task) *ConcurrentTask {
+	return &ConcurrentTask{
+		name:  name,
+		tasks: tasks,
+	}
+}
+
 func (c *ConcurrentTask) Run() error {
 	var g errgroup.Group
 
@@ -41,11 +48,4 @@ func (c *ConcurrentTask) String() string {
 	}
 
 	return buffer.String()
-}
-
-func NewConcurrentTask(name string, tasks ...Task) *ConcurrentTask {
-	return &ConcurrentTask{
-		name:  name,
-		tasks: tasks,
-	}
 }

--- a/tasks/concurrent.go
+++ b/tasks/concurrent.go
@@ -7,6 +7,12 @@ import (
 	"golang.org/x/sync/errgroup"
 )
 
+// ConcurrentTask represent a set of tasks that are executed concurrently using
+// an errgroup.Group.
+// Externally it act as a Task, and as such, can be included on a workflow or
+// wrapped on a retry. Keep in mmind in the latter case that, given the nature
+// of errgroup.Group, on failure the whole task set will be retried, including
+// tasks that potentially have already finished.
 type ConcurrentTask struct {
 	name  string
 	tasks []Task

--- a/tasks/concurrent_test.go
+++ b/tasks/concurrent_test.go
@@ -1,0 +1,84 @@
+package tasks_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/giantswarm/architect/tasks"
+)
+
+type testTask struct {
+	shouldFail bool
+}
+
+func (t *testTask) Name() string {
+	return "test-task"
+}
+
+func (t *testTask) Run() error {
+	if t.shouldFail {
+		return fmt.Errorf("error!")
+	}
+	return nil
+}
+
+func (t *testTask) String() string {
+	return "test-task"
+}
+
+func TestRunConcurrent(t *testing.T) {
+	tcs := []struct {
+		description   string
+		tasks         []tasks.Task
+		expectedError bool
+	}{
+		{
+			description: "all succeed",
+			tasks: []tasks.Task{
+				&testTask{},
+				&testTask{},
+				&testTask{},
+			},
+		},
+		{
+			description: "one fail",
+			tasks: []tasks.Task{
+				&testTask{shouldFail: true},
+				&testTask{},
+				&testTask{},
+			},
+			expectedError: true,
+		},
+		{
+			description: "two fail",
+			tasks: []tasks.Task{
+				&testTask{shouldFail: true},
+				&testTask{shouldFail: true},
+				&testTask{},
+			},
+			expectedError: true,
+		},
+		{
+			description: "three fail",
+			tasks: []tasks.Task{
+				&testTask{shouldFail: true},
+				&testTask{shouldFail: true},
+				&testTask{shouldFail: true},
+			},
+			expectedError: true,
+		},
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.description, func(t *testing.T) {
+			task := tasks.NewConcurrentTask("test-concurrent", tc.tasks...)
+			err := task.Run()
+			switch {
+			case err != nil && !tc.expectedError:
+				t.Errorf("unexpected error %v", err)
+			case err == nil && tc.expectedError:
+				t.Errorf("expected error didn't happen")
+			}
+		})
+	}
+}

--- a/vendor/golang.org/x/sync/AUTHORS
+++ b/vendor/golang.org/x/sync/AUTHORS
@@ -1,0 +1,3 @@
+# This source code refers to The Go Authors for copyright purposes.
+# The master list of authors is in the main Go distribution,
+# visible at http://tip.golang.org/AUTHORS.

--- a/vendor/golang.org/x/sync/CONTRIBUTORS
+++ b/vendor/golang.org/x/sync/CONTRIBUTORS
@@ -1,0 +1,3 @@
+# This source code was written by the Go contributors.
+# The master list of contributors is in the main Go distribution,
+# visible at http://tip.golang.org/CONTRIBUTORS.

--- a/vendor/golang.org/x/sync/LICENSE
+++ b/vendor/golang.org/x/sync/LICENSE
@@ -1,0 +1,27 @@
+Copyright (c) 2009 The Go Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/vendor/golang.org/x/sync/PATENTS
+++ b/vendor/golang.org/x/sync/PATENTS
@@ -1,0 +1,22 @@
+Additional IP Rights Grant (Patents)
+
+"This implementation" means the copyrightable works distributed by
+Google as part of the Go project.
+
+Google hereby grants to You a perpetual, worldwide, non-exclusive,
+no-charge, royalty-free, irrevocable (except as stated in this section)
+patent license to make, have made, use, offer to sell, sell, import,
+transfer and otherwise run, modify and propagate the contents of this
+implementation of Go, where such license applies only to those patent
+claims, both currently owned or controlled by Google and acquired in
+the future, licensable by Google that are necessarily infringed by this
+implementation of Go.  This grant does not include claims that would be
+infringed only as a consequence of further modification of this
+implementation.  If you or your agent or exclusive licensee institute or
+order or agree to the institution of patent litigation against any
+entity (including a cross-claim or counterclaim in a lawsuit) alleging
+that this implementation of Go or any code incorporated within this
+implementation of Go constitutes direct or contributory patent
+infringement, or inducement of patent infringement, then any patent
+rights granted to you under this License for this implementation of Go
+shall terminate as of the date such litigation is filed.

--- a/vendor/golang.org/x/sync/errgroup/errgroup.go
+++ b/vendor/golang.org/x/sync/errgroup/errgroup.go
@@ -1,0 +1,67 @@
+// Copyright 2016 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package errgroup provides synchronization, error propagation, and Context
+// cancelation for groups of goroutines working on subtasks of a common task.
+package errgroup
+
+import (
+	"sync"
+
+	"golang.org/x/net/context"
+)
+
+// A Group is a collection of goroutines working on subtasks that are part of
+// the same overall task.
+//
+// A zero Group is valid and does not cancel on error.
+type Group struct {
+	cancel func()
+
+	wg sync.WaitGroup
+
+	errOnce sync.Once
+	err     error
+}
+
+// WithContext returns a new Group and an associated Context derived from ctx.
+//
+// The derived Context is canceled the first time a function passed to Go
+// returns a non-nil error or the first time Wait returns, whichever occurs
+// first.
+func WithContext(ctx context.Context) (*Group, context.Context) {
+	ctx, cancel := context.WithCancel(ctx)
+	return &Group{cancel: cancel}, ctx
+}
+
+// Wait blocks until all function calls from the Go method have returned, then
+// returns the first non-nil error (if any) from them.
+func (g *Group) Wait() error {
+	g.wg.Wait()
+	if g.cancel != nil {
+		g.cancel()
+	}
+	return g.err
+}
+
+// Go calls the given function in a new goroutine.
+//
+// The first call to return a non-nil error cancels the group; its error will be
+// returned by Wait.
+func (g *Group) Go(f func() error) {
+	g.wg.Add(1)
+
+	go func() {
+		defer g.wg.Done()
+
+		if err := f(); err != nil {
+			g.errOnce.Do(func() {
+				g.err = err
+				if g.cancel != nil {
+					g.cancel()
+				}
+			})
+		}
+	}()
+}

--- a/workflow/golang.go
+++ b/workflow/golang.go
@@ -14,11 +14,12 @@ import (
 )
 
 var (
-	GoPullTaskName  = "go-pull"
-	GoFmtTaskName   = "go-fmt"
-	GoVetTaskName   = "go-vet"
-	GoTestTaskName  = "go-test"
-	GoBuildTaskName = "go-build"
+	GoPullTaskName       = "go-pull"
+	GoFmtTaskName        = "go-fmt"
+	GoVetTaskName        = "go-vet"
+	GoTestTaskName       = "go-test"
+	GoBuildTaskName      = "go-build"
+	GoConcurrentTaskName = "go-concurrent"
 )
 
 func golangFilesExist(fs afero.Fs, directory string) (bool, error) {

--- a/workflow/golang.go
+++ b/workflow/golang.go
@@ -152,9 +152,11 @@ func NewGoVetTask(fs afero.Fs, projectInfo ProjectInfo) (tasks.Task, error) {
 					projectInfo.Organisation,
 					projectInfo.Project,
 				),
+				"/tmp/go/cache:/go/cache",
 			},
 			Env: []string{
 				"GOPATH=/go",
+				"GOCACHE=/go/cache",
 			},
 			WorkingDirectory: fmt.Sprintf(
 				"/go/src/github.com/%v/%v",
@@ -184,10 +186,12 @@ func NewGoTestTask(fs afero.Fs, projectInfo ProjectInfo) (tasks.Task, error) {
 					projectInfo.Organisation,
 					projectInfo.Project,
 				),
+				"/tmp/go/cache:/go/cache",
 			},
 			Env: []string{
 				fmt.Sprintf("GOOS=%v", projectInfo.Goos),
 				fmt.Sprintf("GOARCH=%v", projectInfo.Goarch),
+				"GOCACHE=/go/cache",
 				"GOPATH=/go",
 				"CGOENABLED=0",
 			},
@@ -219,10 +223,12 @@ func NewGoBuildTask(fs afero.Fs, projectInfo ProjectInfo) (tasks.Task, error) {
 					projectInfo.Organisation,
 					projectInfo.Project,
 				),
+				"/tmp/go/cache:/go/cache",
 			},
 			Env: []string{
 				fmt.Sprintf("GOOS=%v", projectInfo.Goos),
 				fmt.Sprintf("GOARCH=%v", projectInfo.Goarch),
+				"GOCACHE=/go/cache",
 				"GOPATH=/go",
 				"CGOENABLED=0",
 			},

--- a/workflow/workflow.go
+++ b/workflow/workflow.go
@@ -81,18 +81,6 @@ func NewBuild(projectInfo ProjectInfo, fs afero.Fs) (Workflow, error) {
 		}
 		w = append(w, goFmt)
 
-		goVet, err := NewGoVetTask(fs, projectInfo)
-		if err != nil {
-			return nil, microerror.Mask(err)
-		}
-		w = append(w, goVet)
-
-		goTest, err := NewGoTestTask(fs, projectInfo)
-		if err != nil {
-			return nil, microerror.Mask(err)
-		}
-		w = append(w, goTest)
-
 		isGoBuildable, err := goBuildable(fs, projectInfo.WorkingDirectory)
 		if err != nil {
 			return nil, microerror.Mask(err)
@@ -104,6 +92,12 @@ func NewBuild(projectInfo ProjectInfo, fs afero.Fs) (Workflow, error) {
 			}
 			w = append(w, goBuild)
 		}
+
+		goTest, err := NewGoTestTask(fs, projectInfo)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+		w = append(w, goTest)
 	}
 
 	dockerFileExists, err := afero.Exists(fs, filepath.Join(projectInfo.WorkingDirectory, "Dockerfile"))

--- a/workflow/workflow.go
+++ b/workflow/workflow.go
@@ -65,15 +65,14 @@ func NewBuild(projectInfo ProjectInfo, fs afero.Fs) (Workflow, error) {
 		return nil, microerror.Mask(err)
 	}
 	if isGolangFilesExist {
-		var goTasks []tasks.Task
-
 		golangPull, err := NewGoPullTask(fs, projectInfo)
 		if err != nil {
 			return nil, microerror.Mask(err)
 		}
 		wrappedGolangPull := tasks.NewRetryTask(backoff.NewExponentialBackOff(), golangPull)
-		goTasks = append(goTasks, wrappedGolangPull)
+		w = append(w, wrappedGolangPull)
 
+		var goTasks []tasks.Task
 		goFmt, err := NewGoFmtTask(fs, projectInfo)
 		if err != nil {
 			return nil, microerror.Mask(err)

--- a/workflow/workflow_test.go
+++ b/workflow/workflow_test.go
@@ -106,9 +106,8 @@ func TestGetBuildWorkflow(t *testing.T) {
 			expectedTaskNames: []string{
 				GoPullTaskName,
 				GoFmtTaskName,
-				GoVetTaskName,
-				GoTestTaskName,
 				GoBuildTaskName,
+				GoTestTaskName,
 			},
 		},
 
@@ -128,7 +127,6 @@ func TestGetBuildWorkflow(t *testing.T) {
 			expectedTaskNames: []string{
 				GoPullTaskName,
 				GoFmtTaskName,
-				GoVetTaskName,
 				GoTestTaskName,
 			},
 		},
@@ -153,7 +151,6 @@ func TestGetBuildWorkflow(t *testing.T) {
 			expectedTaskNames: []string{
 				GoPullTaskName,
 				GoFmtTaskName,
-				GoVetTaskName,
 				GoTestTaskName,
 			},
 		},
@@ -171,9 +168,8 @@ func TestGetBuildWorkflow(t *testing.T) {
 			expectedTaskNames: []string{
 				GoPullTaskName,
 				GoFmtTaskName,
-				GoVetTaskName,
-				GoTestTaskName,
 				GoBuildTaskName,
+				GoTestTaskName,
 			},
 		},
 
@@ -209,9 +205,8 @@ func TestGetBuildWorkflow(t *testing.T) {
 			expectedTaskNames: []string{
 				GoPullTaskName,
 				GoFmtTaskName,
-				GoVetTaskName,
-				GoTestTaskName,
 				GoBuildTaskName,
+				GoTestTaskName,
 				DockerBuildTaskName,
 				DockerRunVersionTaskName,
 				DockerRunHelpTaskName,

--- a/workflow/workflow_test.go
+++ b/workflow/workflow_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"path/filepath"
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/spf13/afero"
@@ -104,10 +105,12 @@ func TestGetBuildWorkflow(t *testing.T) {
 				return nil
 			},
 			expectedTaskNames: []string{
-				GoPullTaskName,
-				GoFmtTaskName,
-				GoBuildTaskName,
-				GoTestTaskName,
+				strings.Join([]string{
+					fmt.Sprintf("retry task '%s'", GoPullTaskName),
+					GoFmtTaskName,
+					GoBuildTaskName,
+					GoTestTaskName,
+				}, ";") + ";",
 			},
 		},
 
@@ -125,9 +128,11 @@ func TestGetBuildWorkflow(t *testing.T) {
 				return nil
 			},
 			expectedTaskNames: []string{
-				GoPullTaskName,
-				GoFmtTaskName,
-				GoTestTaskName,
+				strings.Join([]string{
+					fmt.Sprintf("retry task '%s'", GoPullTaskName),
+					GoFmtTaskName,
+					GoTestTaskName,
+				}, ";") + ";",
 			},
 		},
 
@@ -149,9 +154,11 @@ func TestGetBuildWorkflow(t *testing.T) {
 				return nil
 			},
 			expectedTaskNames: []string{
-				GoPullTaskName,
-				GoFmtTaskName,
-				GoTestTaskName,
+				strings.Join([]string{
+					fmt.Sprintf("retry task '%s'", GoPullTaskName),
+					GoFmtTaskName,
+					GoTestTaskName,
+				}, ";") + ";",
 			},
 		},
 
@@ -166,10 +173,12 @@ func TestGetBuildWorkflow(t *testing.T) {
 				return nil
 			},
 			expectedTaskNames: []string{
-				GoPullTaskName,
-				GoFmtTaskName,
-				GoBuildTaskName,
-				GoTestTaskName,
+				strings.Join([]string{
+					fmt.Sprintf("retry task '%s'", GoPullTaskName),
+					GoFmtTaskName,
+					GoBuildTaskName,
+					GoTestTaskName,
+				}, ";") + ";",
 			},
 		},
 
@@ -203,10 +212,12 @@ func TestGetBuildWorkflow(t *testing.T) {
 				return nil
 			},
 			expectedTaskNames: []string{
-				GoPullTaskName,
-				GoFmtTaskName,
-				GoBuildTaskName,
-				GoTestTaskName,
+				strings.Join([]string{
+					fmt.Sprintf("retry task '%s'", GoPullTaskName),
+					GoFmtTaskName,
+					GoBuildTaskName,
+					GoTestTaskName,
+				}, ";") + ";",
 				DockerBuildTaskName,
 				DockerRunVersionTaskName,
 				DockerRunHelpTaskName,

--- a/workflow/workflow_test.go
+++ b/workflow/workflow_test.go
@@ -105,8 +105,8 @@ func TestGetBuildWorkflow(t *testing.T) {
 				return nil
 			},
 			expectedTaskNames: []string{
+				GoPullTaskName,
 				strings.Join([]string{
-					fmt.Sprintf("retry task '%s'", GoPullTaskName),
 					GoFmtTaskName,
 					GoBuildTaskName,
 					GoTestTaskName,
@@ -128,8 +128,8 @@ func TestGetBuildWorkflow(t *testing.T) {
 				return nil
 			},
 			expectedTaskNames: []string{
+				GoPullTaskName,
 				strings.Join([]string{
-					fmt.Sprintf("retry task '%s'", GoPullTaskName),
 					GoFmtTaskName,
 					GoTestTaskName,
 				}, ";") + ";",
@@ -154,8 +154,8 @@ func TestGetBuildWorkflow(t *testing.T) {
 				return nil
 			},
 			expectedTaskNames: []string{
+				GoPullTaskName,
 				strings.Join([]string{
-					fmt.Sprintf("retry task '%s'", GoPullTaskName),
 					GoFmtTaskName,
 					GoTestTaskName,
 				}, ";") + ";",
@@ -173,8 +173,8 @@ func TestGetBuildWorkflow(t *testing.T) {
 				return nil
 			},
 			expectedTaskNames: []string{
+				GoPullTaskName,
 				strings.Join([]string{
-					fmt.Sprintf("retry task '%s'", GoPullTaskName),
 					GoFmtTaskName,
 					GoBuildTaskName,
 					GoTestTaskName,
@@ -212,8 +212,8 @@ func TestGetBuildWorkflow(t *testing.T) {
 				return nil
 			},
 			expectedTaskNames: []string{
+				GoPullTaskName,
 				strings.Join([]string{
-					fmt.Sprintf("retry task '%s'", GoPullTaskName),
 					GoFmtTaskName,
 					GoBuildTaskName,
 					GoTestTaskName,


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/2711 and https://github.com/giantswarm/giantswarm/issues/2678

Adds a `ConcurrentTask` type that runs a set of tasks concurrently using `errgroup.Group`. Also introduces changes to run the Go tasks concurrently, this is compatible with the changes introduced in #203, if we want to reuse the cache from the build step we just need to remove the build task from the concurrent set and execute it in the first place. We can measure in which situation we can have more gains (run build and test sequentially and take advantage of build cache in test or run build and test concurrently without cache).

This concurrent task can be used in more workflows, if we agree on the approach I'll propose more changes next.