### PR TITLE
Add docker pull task to deploy workflow

### DIFF
--- a/workflow/docker.go
+++ b/workflow/docker.go
@@ -17,6 +17,7 @@ const (
 	DockerTagLatestTaskName  = "docker-tag-latest"
 	DockerPushShaTaskName    = "docker-push-sha"
 	DockerPushLatestTaskName = "docker-push-latest"
+	DockerPullTaskName       = "docker-pull"
 
 	// DockerImageRefFmt is the format string used to compute the reference of the
 	// Docker image used to build and push. It may look something like this.
@@ -177,6 +178,23 @@ func NewDockerPushLatestTask(fs afero.Fs, projectInfo ProjectInfo) (tasks.Task, 
 	)
 
 	return dockerPush, nil
+}
+
+func NewDockerPullTask(fs afero.Fs, projectInfo ProjectInfo) (tasks.Task, error) {
+	if err := checkDockerRequirements(projectInfo); err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	dockerPull := tasks.NewExecTask(
+		DockerPullTaskName,
+		[]string{
+			"docker",
+			"pull",
+			newDockerImageRef(projectInfo, projectInfo.Sha),
+		},
+	)
+
+	return dockerPull, nil
 }
 
 func newDockerImageRef(projectInfo ProjectInfo, version string) string {

--- a/workflow/docker_test.go
+++ b/workflow/docker_test.go
@@ -108,6 +108,18 @@ func Test_Workflow_Docker_NewDockerBuildTask(t *testing.T) {
 				"quay.io/giantswarm/architect:latest",
 			},
 		},
+
+		// Test 8, make sure NewDockerPullTask works as expected.
+		{
+			TaskFunc: func() (tasks.Task, error) {
+				return NewDockerPullTask(nil, testNewProjectInfo())
+			},
+			ExpectedArgs: []string{
+				"docker",
+				"pull",
+				"quay.io/giantswarm/architect:e8363ac222255e991c126abe6673cd0f33934ac8",
+			},
+		},
 	}
 
 	for i, tc := range testCases {

--- a/workflow/workflow.go
+++ b/workflow/workflow.go
@@ -226,6 +226,12 @@ func NewDeploy(projectInfo ProjectInfo, fs afero.Fs) (Workflow, error) {
 			w = append(w, wrappedDockerLogin)
 		}
 
+		dockerPull, err := NewDockerPullTask(fs, projectInfo)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+		w = append(w, dockerPull)
+
 		dockerTagLatest, err := NewDockerTagLatestTask(fs, projectInfo)
 		if err != nil {
 			return nil, microerror.Mask(err)

--- a/workflow/workflow_test.go
+++ b/workflow/workflow_test.go
@@ -375,6 +375,7 @@ func TestGetDeployWorkflow(t *testing.T) {
 			},
 			expectedTaskNames: []string{
 				DockerLoginTaskName,
+				DockerPullTaskName,
 				DockerTagLatestTaskName,
 				DockerPushLatestTaskName,
 			},
@@ -395,6 +396,7 @@ func TestGetDeployWorkflow(t *testing.T) {
 			},
 			expectedTaskNames: []string{
 				DockerLoginTaskName,
+				DockerPullTaskName,
 				DockerTagLatestTaskName,
 				DockerPushLatestTaskName,
 			},


### PR DESCRIPTION
Currently all the repos run `architect deploy` as part of the single `build` job, as in https://github.com/giantswarm/kvm-operator/blob/master/.circleci/config.yml#L16

When we introduced e2e tests in aws-operator this way of deploying was kept until we have fast and reliable tests; after merging to master we build, deploy, and then we run e2e tests. We aim to condition the deployment to the result of the e2e tests, and only deploy when we are confident that things are working.

For that we need to have a separate `deploy` job, as in https://github.com/giantswarm/chart-operator/blob/master/.circleci/config.yml first build, then e2e tests and then, if things went well, deploy. The problem is that the final deploy step is run in a machine different from the one that did the build, and the task for tagging the image with `latest` fails because it doesn't find locally the image built.

This PR solves the issue by adding a docker pull task, it won't make single-step build+deploy fail (we'll get "Already exists" messages for each layer and a final "Status: Image is up to date" message) and will make multi-step build and deploy succeed.