### PR TITLE
workflow: make go builds and tests less verbose

### DIFF
--- a/workflow/golang.go
+++ b/workflow/golang.go
@@ -202,7 +202,7 @@ func NewGoTestTask(fs afero.Fs, projectInfo ProjectInfo) (tasks.Task, error) {
 				projectInfo.Project,
 			),
 			Image: fmt.Sprintf("%v:%v", projectInfo.GolangImage, projectInfo.GolangVersion),
-			Args:  []string{"go", "test", "-v", "-race", "./..."},
+			Args:  []string{"go", "test", "-race", "./..."},
 		},
 	)
 
@@ -241,7 +241,6 @@ func NewGoBuildTask(fs afero.Fs, projectInfo ProjectInfo) (tasks.Task, error) {
 			Image: fmt.Sprintf("%v:%v", projectInfo.GolangImage, projectInfo.GolangVersion),
 			Args: []string{
 				"go", "build",
-				"-v",
 				"-a",
 				"-tags", "netgo",
 				"-ldflags", fmt.Sprintf(


### PR DESCRIPTION
When something breaks it's difficult to realize what went wrong. Also circle elides long output.