### PR TITLE
WIP: Only test go packages

### DIFF
--- a/workflow/error.go
+++ b/workflow/error.go
@@ -6,7 +6,7 @@ import (
 
 var noCertEnvVarError = microerror.New("no cert env var")
 
-// IsNoCertEnvVar asserts multipleHelmChartsError.
+// IsNoCertEnvVar asserts noCertEnvVarError
 func IsNoCertEnvVar(err error) bool {
 	return microerror.Cause(err) == noCertEnvVarError
 }

--- a/workflow/error.go
+++ b/workflow/error.go
@@ -11,6 +11,13 @@ func IsNoCertEnvVar(err error) bool {
 	return microerror.Cause(err) == noCertEnvVarError
 }
 
+var noGolangPackagesError = microerror.New("no golang packages found")
+
+// IsNoGolangPackages asserts noGolangPackagesError
+func IsNoGolangPackages(err error) bool {
+	return microerror.Cause(err) == noGolangPackagesError
+}
+
 var decodeCertError = microerror.New("decode cert")
 
 // IsDecodeCert asserts decodeCertError

--- a/workflow/workflow.go
+++ b/workflow/workflow.go
@@ -91,11 +91,17 @@ func NewBuild(projectInfo ProjectInfo, fs afero.Fs) (Workflow, error) {
 			goTasks = append(goTasks, goBuild)
 		}
 
-		goTest, err := NewGoTestTask(fs, projectInfo)
+		isGoTestable, err := goTestable()
 		if err != nil {
 			return nil, microerror.Mask(err)
 		}
-		goTasks = append(goTasks, goTest)
+		if isGoTestable {
+			goTest, err := NewGoTestTask(fs, projectInfo)
+			if err != nil {
+				return nil, microerror.Mask(err)
+			}
+			goTasks = append(goTasks, goTest)
+		}
 
 		goConcurrentTask := tasks.NewConcurrentTask(GoConcurrentTaskName, goTasks...)
 

--- a/workflow/workflow_test.go
+++ b/workflow/workflow_test.go
@@ -302,6 +302,28 @@ func TestGetBuildWorkflow(t *testing.T) {
 			},
 			errorMatcher: IsInvalidHelmDirectory,
 		},
+
+		// Test 11 that a project with only golang files that have build contraints
+		// do not trigger a test workflow.
+		{
+			setUp: func(fs afero.Fs) error {
+				if err := fs.Mkdir(filepath.Join(projectInfo.WorkingDirectory, "integration"), 0644); err != nil {
+					return microerror.Mask(err)
+				}
+				if err := afero.WriteFile(fs, filepath.Join(projectInfo.WorkingDirectory, "integration", "integration_test.go"), []byte("// +build k8srequired"), 0644); err != nil {
+					return microerror.Mask(err)
+				}
+
+				return nil
+			},
+			expectedTaskNames: []string{
+				GoPullTaskName,
+				strings.Join([]string{
+					GoFmtTaskName,
+					GoBuildTaskName,
+				}, ";") + ";",
+			},
+		},
 	}
 
 	for i, tc := range tests {


### PR DESCRIPTION
Hey guys I need a little bit of help here, also early feedback in general is appreciated <3

I added a condition to the goTestTask, that  only runs when there are actual go packages to be tested.
(We need this for integration test for i.e. helm charts, where no other go code is present than the e2e-test, which have the build constraint)

Problem is, my test of this workflow fails, cause the bash command
`go list ./... <2 | wc -l` is executed in the actual testing directory and not on the `afero.Fs` Filesystem. 
Is there any way around this? I am a bit stuck how to deal with this.