### PR TITLE
Fail build on upload error

### DIFF
--- a/github-release.sh
+++ b/github-release.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 SHA=$1
 PERSONAL_ACCESS_TOKEN=$2
 
@@ -44,12 +46,18 @@ echo $release_output | jq
 RELEASE_ID=$(echo $release_output | jq '.id')
 
 echo "Upload binary to GitHub Release"
-upload_output=$(curl \
+upload_status=$(curl \
+    -s -o /dev/null -w "%{http_code}" \
     --header "Authorization: token ${PERSONAL_ACCESS_TOKEN}" \
     --header "Content-Type: application/octet-stream" \
     --data-binary @architect \
     https://uploads.github.com/repos/giantswarm/architect/releases/${RELEASE_ID}/assets?name=architect
 )
-echo $upload_output | jq
+
+code=${upload_status:0:1}
+if [ "$code" != "2" ]; then
+    echo "Upload failed, status code $upload_status"
+    exit 1
+fi
 
 echo "Done!"


### PR DESCRIPTION
Closes https://github.com/giantswarm/architect/issues/195

Instead of showing the json response on upload we get the http status code and check for a 2xx, anything different from that will fail the build.