### PR TITLE
Enable push to stable for multiple charts

### DIFF
--- a/workflow/helm.go
+++ b/workflow/helm.go
@@ -106,6 +106,15 @@ func NewHelmPushTask(fs afero.Fs, chartDir string, projectInfo ProjectInfo) (tas
 	return helmPush, nil
 }
 
+func NewHelmPromoteToStableChannelTask(fs afero.Fs, chartDir string, projectInfo ProjectInfo) (tasks.Task, error) {
+	t, err := NewHelmPromoteToChannelTask(fs, chartDir, projectInfo, "stable")
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	return t, nil
+}
+
 func NewHelmPromoteToChannelTask(fs afero.Fs, chartDir string, projectInfo ProjectInfo, channel string) (tasks.Task, error) {
 	cnrDir, err := cnrDirectory()
 	if err != nil {

--- a/workflow/workflow.go
+++ b/workflow/workflow.go
@@ -154,63 +154,12 @@ func NewBuild(projectInfo ProjectInfo, fs afero.Fs) (Workflow, error) {
 		}
 	}
 
-	helmDirectory := filepath.Join(projectInfo.WorkingDirectory, "helm")
-	helmDirectoryExists, err := afero.Exists(fs, helmDirectory)
+	helmTasks, err := processHelmDir(fs, projectInfo, NewHelmPushTask)
 	if err != nil {
 		return nil, microerror.Mask(err)
 	}
-	if helmDirectoryExists {
-		{
-			helmPull, err := NewHelmPullTask(fs, projectInfo)
-			if err != nil {
-				return nil, microerror.Mask(err)
-			}
-			wrappedHelmPull := tasks.NewRetryTask(backoff.NewExponentialBackOff(), helmPull)
 
-			w = append(w, wrappedHelmPull)
-		}
-
-		fileInfos, err := afero.ReadDir(fs, helmDirectory)
-		if err != nil {
-			return nil, microerror.Mask(err)
-		}
-
-		if len(fileInfos) > 0 {
-			helmLogin, err := NewHelmLoginTask(fs, projectInfo)
-			if err != nil {
-				return nil, microerror.Mask(err)
-			}
-			w = append(w, helmLogin)
-		}
-
-		prefix := projectInfo.Project + "-"
-		suffix := "-chart"
-		for _, fileInfo := range fileInfos {
-			if !fileInfo.IsDir() {
-				return nil, microerror.Maskf(invalidHelmDirectoryError, "%q is not a directory", fileInfo.Name())
-			}
-			if !strings.HasPrefix(fileInfo.Name(), prefix) {
-				return nil, microerror.Maskf(invalidHelmDirectoryError, "%q must start with %q", fileInfo.Name(), prefix)
-			}
-			if !strings.HasSuffix(fileInfo.Name(), suffix) {
-				return nil, microerror.Maskf(invalidHelmDirectoryError, "%q must end with %q", fileInfo.Name(), suffix)
-			}
-
-			chartDir := filepath.Join(helmDirectory, fileInfo.Name())
-
-			helmChartTemplate, err := NewTemplateHelmChartTask(fs, chartDir, projectInfo)
-			if err != nil {
-				return nil, microerror.Mask(err)
-			}
-			w = append(w, helmChartTemplate)
-
-			helmPush, err := NewHelmPushTask(fs, chartDir, projectInfo)
-			if err != nil {
-				return nil, microerror.Mask(err)
-			}
-			w = append(w, helmPush)
-		}
-	}
+	w = append(w, helmTasks...)
 
 	return w, nil
 }
@@ -254,44 +203,12 @@ func NewDeploy(projectInfo ProjectInfo, fs afero.Fs) (Workflow, error) {
 		}
 	}
 
-	chartDirectory := filepath.Join(projectInfo.WorkingDirectory, "helm", projectInfo.Project+"-chart")
-	chartDirectoryExists, err := afero.Exists(fs, chartDirectory)
+	helmTasks, err := processHelmDir(fs, projectInfo, NewHelmPromoteToStableChannelTask)
 	if err != nil {
 		return nil, microerror.Mask(err)
 	}
-	if chartDirectoryExists {
-		{
-			helmPull, err := NewHelmPullTask(fs, projectInfo)
-			if err != nil {
-				return nil, microerror.Mask(err)
-			}
-			wrappedHelmPull := tasks.NewRetryTask(backoff.NewExponentialBackOff(), helmPull)
 
-			fmt.Printf("adding wrappedHelmPull %v\n", chartDirectory)
-			w = append(w, wrappedHelmPull)
-		}
-
-		helmChartTemplate, err := NewTemplateHelmChartTask(fs, chartDirectory, projectInfo)
-		if err != nil {
-			return nil, microerror.Mask(err)
-		}
-		w = append(w, helmChartTemplate)
-
-		helmLogin, err := NewHelmLoginTask(fs, projectInfo)
-		if err != nil {
-			return nil, microerror.Mask(err)
-		}
-		w = append(w, helmLogin)
-
-		helmPromoteToChannel, err := NewHelmPromoteToChannelTask(fs, chartDirectory, projectInfo, "stable")
-		if err != nil {
-			return nil, microerror.Mask(err)
-		}
-
-		wrappedHelmPromoteToChannel := tasks.NewRetryTask(backoff.NewExponentialBackOff(), helmPromoteToChannel)
-
-		w = append(w, wrappedHelmPromoteToChannel)
-	}
+	w = append(w, helmTasks...)
 
 	return w, nil
 }
@@ -326,5 +243,70 @@ func NewPublish(projectInfo ProjectInfo, fs afero.Fs) (Workflow, error) {
 			w = append(w, wrappedHelmPromoteToChannel)
 		}
 	}
+	return w, nil
+}
+
+func processHelmDir(fs afero.Fs, projectInfo ProjectInfo, f func(afero.Fs, string, ProjectInfo) (tasks.Task, error)) (Workflow, error) {
+	var w = Workflow{}
+
+	helmDirectory := filepath.Join(projectInfo.WorkingDirectory, "helm")
+	helmDirectoryExists, err := afero.Exists(fs, helmDirectory)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+	if helmDirectoryExists {
+		fileInfos, err := afero.ReadDir(fs, helmDirectory)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+
+		if len(fileInfos) > 0 {
+			helmPull, err := NewHelmPullTask(fs, projectInfo)
+			if err != nil {
+				return nil, microerror.Mask(err)
+			}
+			wrappedHelmPull := tasks.NewRetryTask(backoff.NewExponentialBackOff(), helmPull)
+
+			w = append(w, wrappedHelmPull)
+
+			helmLogin, err := NewHelmLoginTask(fs, projectInfo)
+			if err != nil {
+				return nil, microerror.Mask(err)
+			}
+			w = append(w, helmLogin)
+		}
+
+		prefix := projectInfo.Project + "-"
+		suffix := "-chart"
+		for _, fileInfo := range fileInfos {
+			if !fileInfo.IsDir() {
+				return nil, microerror.Maskf(invalidHelmDirectoryError, "%q is not a directory", fileInfo.Name())
+			}
+			if !strings.HasPrefix(fileInfo.Name(), prefix) {
+				return nil, microerror.Maskf(invalidHelmDirectoryError, "%q must start with %q", fileInfo.Name(), prefix)
+			}
+			if !strings.HasSuffix(fileInfo.Name(), suffix) {
+				return nil, microerror.Maskf(invalidHelmDirectoryError, "%q must end with %q", fileInfo.Name(), suffix)
+			}
+
+			chartDir := filepath.Join(helmDirectory, fileInfo.Name())
+
+			helmChartTemplate, err := NewTemplateHelmChartTask(fs, chartDir, projectInfo)
+			if err != nil {
+				return nil, microerror.Mask(err)
+			}
+			w = append(w, helmChartTemplate)
+
+			helmTask, err := f(fs, chartDir, projectInfo)
+			if err != nil {
+				return nil, microerror.Mask(err)
+			}
+
+			wrappedHelmTask := tasks.NewRetryTask(backoff.NewExponentialBackOff(), helmTask)
+
+			w = append(w, wrappedHelmTask)
+		}
+	}
+
 	return w, nil
 }

--- a/workflow/workflow_test.go
+++ b/workflow/workflow_test.go
@@ -453,28 +453,14 @@ func TestGetDeployWorkflow(t *testing.T) {
 			},
 			expectedTaskNames: []string{
 				HelmPullTaskName,
-				template.TemplateHelmChartTaskName,
 				HelmLoginTaskName,
+				template.TemplateHelmChartTaskName,
 				pushTaskName,
 			},
 		},
 
-		// Test 4 a project with a helm/PROJECT-something-chart directory
-		// doesn't push helm chart as it isn't main chart.
-		{
-			setUp: func(fs afero.Fs) error {
-				if err := fs.MkdirAll(filepath.Join(projectInfo.WorkingDirectory, "helm/test-project-something-chart"), 0644); err != nil {
-					return microerror.Mask(err)
-				}
-
-				return nil
-			},
-			expectedTaskNames: []string{},
-		},
-
-		// Test 5 a project with a helm/PROJECT-chart and
-		// helm/PROJECT-something-chart directories pushes only one
-		// (main) chart.
+		// Test 4 a project with a helm/PROJECT-chart and
+		// helm/PROJECT-something-chart directories pushes both charts
 		{
 			setUp: func(fs afero.Fs) error {
 				if err := fs.MkdirAll(filepath.Join(projectInfo.WorkingDirectory, "helm/test-project-chart"), 0644); err != nil {
@@ -488,8 +474,10 @@ func TestGetDeployWorkflow(t *testing.T) {
 			},
 			expectedTaskNames: []string{
 				HelmPullTaskName,
-				template.TemplateHelmChartTaskName,
 				HelmLoginTaskName,
+				template.TemplateHelmChartTaskName,
+				pushTaskName,
+				template.TemplateHelmChartTaskName,
 				pushTaskName,
 			},
 		},


### PR DESCRIPTION
Currently only `<project-name>-chart` is being pushed to stable on deploy, to be able to install from channel additional charts in a helm directory we need to push to stable all of them.