### PR TITLE
Add unpublish command

### DIFF
--- a/cmd/unpublish.go
+++ b/cmd/unpublish.go
@@ -1,0 +1,75 @@
+package cmd
+
+import (
+	"log"
+	"os"
+	"strings"
+
+	"github.com/spf13/afero"
+	"github.com/spf13/cobra"
+
+	"github.com/giantswarm/architect/tasks"
+	"github.com/giantswarm/architect/workflow"
+)
+
+var (
+	unpublishCmd = &cobra.Command{
+		Use:   "unpublish",
+		Short: "unpublish charts from the specified channels",
+		Run:   runUnpublish,
+	}
+)
+
+func init() {
+	RootCmd.AddCommand(unpublishCmd)
+
+	var defaultDockerUsername string
+	var defaultDockerPassword string
+
+	if os.Getenv("CIRCLECI") == "true" {
+		defaultDockerUsername = os.Getenv("QUAY_USERNAME")
+		defaultDockerPassword = os.Getenv("QUAY_PASSWORD")
+	}
+
+	publishCmd.Flags().StringVar(&dockerUsername, "docker-username", defaultDockerUsername, "username to use to login to docker registry")
+	publishCmd.Flags().StringVar(&dockerPassword, "docker-password", defaultDockerPassword, "password to use to login to docker registry")
+
+	publishCmd.Flags().StringVar(&channels, "channels", "beta,testing", "channels to unpublish the charts from, separated by comma")
+}
+
+func runUnpublish(cmd *cobra.Command, args []string) {
+	fs := afero.NewOsFs()
+
+	chs := strings.Split(channels, ",")
+
+	projectInfo := workflow.ProjectInfo{
+		WorkingDirectory: workingDirectory,
+		Organisation:     organisation,
+		Project:          project,
+
+		Branch: branch,
+		Sha:    sha,
+
+		Registry:       registry,
+		DockerUsername: dockerUsername,
+		DockerPassword: dockerPassword,
+
+		Channels: chs,
+	}
+
+	workflow, err := workflow.NewUnpublish(projectInfo, fs)
+	if err != nil {
+		log.Fatalf("could not get workflow: %v", err)
+	}
+
+	log.Printf("running workflow: %s\n", workflow)
+
+	if dryRun {
+		log.Printf("dry run, not actually running workflow")
+		return
+	}
+
+	if err := tasks.Run(workflow); err != nil {
+		log.Fatalf("could not execute workflow: %v", err)
+	}
+}

--- a/cmd/unpublish.go
+++ b/cmd/unpublish.go
@@ -31,10 +31,10 @@ func init() {
 		defaultDockerPassword = os.Getenv("QUAY_PASSWORD")
 	}
 
-	publishCmd.Flags().StringVar(&dockerUsername, "docker-username", defaultDockerUsername, "username to use to login to docker registry")
-	publishCmd.Flags().StringVar(&dockerPassword, "docker-password", defaultDockerPassword, "password to use to login to docker registry")
+	unpublishCmd.Flags().StringVar(&dockerUsername, "docker-username", defaultDockerUsername, "username to use to login to docker registry")
+	unpublishCmd.Flags().StringVar(&dockerPassword, "docker-password", defaultDockerPassword, "password to use to login to docker registry")
 
-	publishCmd.Flags().StringVar(&channels, "channels", "beta,testing", "channels to unpublish the charts from, separated by comma")
+	unpublishCmd.Flags().StringVar(&channels, "channels", "beta,testing", "channels to unpublish the charts from, separated by comma")
 }
 
 func runUnpublish(cmd *cobra.Command, args []string) {

--- a/workflow/helm.go
+++ b/workflow/helm.go
@@ -162,7 +162,7 @@ func NewHelmDeleteFromChannelTask(fs afero.Fs, chartDir string, projectInfo Proj
 			Args: []string{
 				"registry",
 				"channel",
-				fmt.Sprintf("%v/%v/%v/%s", projectInfo.Registry, projectInfo.Organisation, projectInfo.Project, "-chart"),
+				fmt.Sprintf("%v/%v/%v%s", projectInfo.Registry, projectInfo.Organisation, projectInfo.Project, "-chart"),
 				"--delete",
 				fmt.Sprintf("--channel=%s", channel),
 			},

--- a/workflow/helm.go
+++ b/workflow/helm.go
@@ -157,7 +157,6 @@ func NewHelmDeleteFromChannelTask(fs afero.Fs, chartDir string, projectInfo Proj
 			Image:            HelmImage,
 			Volumes: []string{
 				fmt.Sprintf("%v:/root/.cnr/", cnrDir),
-				fmt.Sprintf("%v:%v", chartDir, chartDir),
 			},
 			Args: []string{
 				"registry",

--- a/workflow/helm.go
+++ b/workflow/helm.go
@@ -17,9 +17,10 @@ const (
 )
 
 var (
-	HelmPullTaskName  = "helm-pull"
-	HelmLoginTaskName = "helm-login"
-	HelmPushTaskName  = "helm-push"
+	HelmPullTaskName          = "helm-pull"
+	HelmLoginTaskName         = "helm-login"
+	HelmPushTaskName          = "helm-push"
+	HelmDeleteChannelTaskName = "helm-delete-channel"
 )
 
 func cnrDirectory() (string, error) {
@@ -141,4 +142,32 @@ func NewHelmPromoteToChannelTask(fs afero.Fs, chartDir string, projectInfo Proje
 	)
 
 	return helmPromoteToChannel, nil
+}
+
+func NewHelmDeleteFromChannelTask(fs afero.Fs, chartDir string, projectInfo ProjectInfo, channel string) (tasks.Task, error) {
+	cnrDir, err := cnrDirectory()
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	helmDeleteFromChannel := tasks.NewDockerTask(
+		fmt.Sprintf("%s-%s", HelmDeleteChannelTaskName, channel),
+		tasks.DockerTaskConfig{
+			WorkingDirectory: chartDir,
+			Image:            HelmImage,
+			Volumes: []string{
+				fmt.Sprintf("%v:/root/.cnr/", cnrDir),
+				fmt.Sprintf("%v:%v", chartDir, chartDir),
+			},
+			Args: []string{
+				"registry",
+				"channel",
+				fmt.Sprintf("%v/%v/%v/%s", projectInfo.Registry, projectInfo.Organisation, projectInfo.Project, "-chart"),
+				"--delete",
+				fmt.Sprintf("--channel=%s", channel),
+			},
+		},
+	)
+
+	return helmDeleteFromChannel, nil
 }

--- a/workflow/workflow.go
+++ b/workflow/workflow.go
@@ -246,6 +246,11 @@ func NewPublish(projectInfo ProjectInfo, fs afero.Fs) (Workflow, error) {
 	return w, nil
 }
 
+func NewUnpublish(projectInfo ProjectInfo, fs afero.Fs) (Workflow, error) {
+	w := Workflow{}
+	return w, nil
+}
+
 func processHelmDir(fs afero.Fs, projectInfo ProjectInfo, f func(afero.Fs, string, ProjectInfo) (tasks.Task, error)) (Workflow, error) {
 	var w = Workflow{}
 

--- a/workflow/workflow_test.go
+++ b/workflow/workflow_test.go
@@ -602,3 +602,96 @@ func TestGetPublishWorkflow(t *testing.T) {
 		})
 	}
 }
+
+func TestGetUnpublishWorkflow(t *testing.T) {
+	projectInfo := ProjectInfo{
+		WorkingDirectory: "/test-project/",
+		Organisation:     "giantswarm",
+		Project:          "test-project",
+		Sha:              "1cd72a25e16e93da14f08d95bd98662f8827028e",
+		Registry:         "quay.io",
+		DockerUsername:   "test",
+		DockerPassword:   "test",
+	}
+
+	setUp := func(fs afero.Fs) error {
+		if err := fs.MkdirAll(filepath.Join(projectInfo.WorkingDirectory, "helm/test-project-chart"), 0644); err != nil {
+			return microerror.Mask(err)
+		}
+		return nil
+	}
+
+	tcs := []struct {
+		description       string
+		channels          []string
+		expectedTaskNames []string
+		expectedError     error
+	}{
+		{
+			description: "default channels",
+			channels:    []string{"beta", "testing"},
+			expectedTaskNames: []string{
+				"helm-login",
+				fmt.Sprintf("%s-beta", HelmDeleteChannelTaskName),
+				fmt.Sprintf("%s-testing", HelmDeleteChannelTaskName),
+			},
+		},
+		{
+			description: "single channel",
+			channels:    []string{"alpha"},
+			expectedTaskNames: []string{
+				"helm-login",
+				fmt.Sprintf("%s-alpha", HelmDeleteChannelTaskName),
+			},
+		},
+		{
+			description: "multiple channels",
+			channels:    []string{"alpha", "beta", "testing", "unstable"},
+			expectedTaskNames: []string{
+				"helm-login",
+				fmt.Sprintf("%s-alpha", HelmDeleteChannelTaskName),
+				fmt.Sprintf("%s-beta", HelmDeleteChannelTaskName),
+				fmt.Sprintf("%s-testing", HelmDeleteChannelTaskName),
+				fmt.Sprintf("%s-unstable", HelmDeleteChannelTaskName),
+			},
+		},
+		{
+			description:       "error on empty channels",
+			channels:          []string{"alpha", "beta", "", "unstable", ""},
+			expectedTaskNames: []string{},
+			expectedError:     emptyChannelError,
+		},
+	}
+
+	for _, tc := range tcs {
+		fs := afero.NewMemMapFs()
+		t.Run(tc.description, func(t *testing.T) {
+			if err := setUp(fs); err != nil {
+				t.Errorf("received unexpected error during setup: %v", err)
+			}
+
+			projectInfo.Channels = tc.channels
+			workflow, err := NewUnpublish(projectInfo, fs)
+			if tc.expectedError != nil && err == nil {
+				t.Errorf("expected error didn't happen")
+			}
+			if err != nil && tc.expectedError != nil && err.Error() != tc.expectedError.Error() {
+				t.Errorf("received unexpected error getting build workflow: %v", err)
+			}
+
+			taskNames := []string{}
+			for _, task := range workflow {
+				retryTask, ok := task.(tasks.RetryTask)
+				if ok {
+					taskNames = append(taskNames, retryTask.Task.Name())
+				} else {
+					taskNames = append(taskNames, task.Name())
+				}
+			}
+
+			if !reflect.DeepEqual(taskNames, tc.expectedTaskNames) {
+				t.Errorf("expected %v tasks, got %v", tc.expectedTaskNames, taskNames)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/1902, https://github.com/giantswarm/giantswarm/issues/2706.

Add `architect unpublish` to cleanup channels on the CNR after pushing to temporary channels. This needed e.g. in guest cluster charts, where channels get created only for a specific CI helm test run.