### PR TITLE
Adds support for stripping DWARF from binaries

### DIFF
--- a/workflow/golang.go
+++ b/workflow/golang.go
@@ -260,7 +260,7 @@ func NewGoBuildTask(fs afero.Fs, projectInfo ProjectInfo) (tasks.Task, error) {
 				"-a",
 				"-tags", "netgo",
 				"-ldflags", fmt.Sprintf(
-					"-X main.gitCommit=%s -linkmode 'external' -extldflags '-static'",
+					"-w -X main.gitCommit=%s -linkmode 'external' -extldflags '-static'",
 					projectInfo.Sha,
 				),
 			},


### PR DESCRIPTION
Closes https://github.com/giantswarm/architect/issues/123

```
$ wc -c ./api
19247544 ./api
$ wc -c ./api
13418280 ./api
```
`api` sees about 30% reduction in total binary size

```
$ wc -c ./aws-operator
81727136 ./aws-operator
$ wc -c ./aws-operator
55810232 ./aws-operator
```
Same for `aws-operator`

See https://golang.org/doc/gdb#Introduction for additional information.