### PR TITLE
Upgrade default golang version to 1.10.4

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -54,7 +54,7 @@ func init() {
 	buildCmd.Flags().StringVar(&helmDirectoryPath, "helm-directory-path", "./helm", "directory holding helm chart")
 
 	buildCmd.Flags().StringVar(&golangImage, "golang-image", "quay.io/giantswarm/golang", "golang image")
-	buildCmd.Flags().StringVar(&golangVersion, "golang-version", "1.10.3", "golang version")
+	buildCmd.Flags().StringVar(&golangVersion, "golang-version", "1.10.4", "golang version")
 }
 
 func runBuild(cmd *cobra.Command, args []string) {


### PR DESCRIPTION
We have a golang 1.10.4 image as of https://github.com/giantswarm/retagger/pull/138