### PR TITLE
Revert "remove-route53-from-girafe (#253)"

### DIFF
--- a/events/events.go
+++ b/events/events.go
@@ -81,7 +81,7 @@ var environmentProjects = map[Environment][]string{
 	"geckon":    kvmProjectList,
 	"ghost":     azureProjectList,
 	"ginger":    awsProjectList,
-	"giraffe":   awsProjectList,
+	"giraffe":   awsChinaProjectList,
 	"godsmack":  azureProjectList,
 	"gollum":    azureProjectList,
 	"gorgoth":   kvmProjectList,


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/4282
route53-manager installation fix is merged: https://github.com/giantswarm/route53-manager/pull/9

This reverts commit 46bc99f2e304b3fb43d6050f0ffe373dc085d9af. from: https://github.com/giantswarm/architect/pull/253
