### PR TITLE
update golang version to 1.11.1

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -54,7 +54,7 @@ func init() {
 	buildCmd.Flags().StringVar(&helmDirectoryPath, "helm-directory-path", "./helm", "directory holding helm chart")
 
 	buildCmd.Flags().StringVar(&golangImage, "golang-image", "quay.io/giantswarm/golang", "golang image")
-	buildCmd.Flags().StringVar(&golangVersion, "golang-version", "1.10.4", "golang version")
+	buildCmd.Flags().StringVar(&golangVersion, "golang-version", "1.11.1", "golang version")
 }
 
 func runBuild(cmd *cobra.Command, args []string) {


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/4461

Note: after this PR is merged, we should all move to go 1.11 and reformat repos.