### PR TITLE
workflow: make go test quiet

### DIFF
--- a/tasks/docker_test.go
+++ b/tasks/docker_test.go
@@ -23,7 +23,7 @@ func TestNewDockerTask(t *testing.T) {
 				},
 				WorkingDirectory: "/go/src/github.com/giantswarm/architect",
 				Image:            "golang:1.7.5",
-				Args:             []string{"go", "test", "-v"},
+				Args:             []string{"go", "test"},
 			},
 			inCircle: false,
 			expectedArgs: []string{
@@ -32,7 +32,7 @@ func TestNewDockerTask(t *testing.T) {
 				"-e", "GOOS=linux",
 				"-w", "/go/src/github.com/giantswarm/architect",
 				"golang:1.7.5",
-				"go", "test", "-v",
+				"go", "test",
 			},
 		},
 

--- a/workflow/golang.go
+++ b/workflow/golang.go
@@ -8,11 +8,9 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/spf13/afero"
-
-	"github.com/giantswarm/microerror"
-
 	"github.com/giantswarm/architect/tasks"
+	"github.com/giantswarm/microerror"
+	"github.com/spf13/afero"
 )
 
 var (
@@ -218,7 +216,7 @@ func NewGoTestTask(fs afero.Fs, projectInfo ProjectInfo) (tasks.Task, error) {
 				projectInfo.Project,
 			),
 			Image: fmt.Sprintf("%v:%v", projectInfo.GolangImage, projectInfo.GolangVersion),
-			Args:  []string{"go", "test", "-v", "-race", "./..."},
+			Args:  []string{"go", "test", "-race", "./..."},
 		},
 	)
 


### PR DESCRIPTION
I don't want to waste time to figure out what's wrong with builds like https://circleci.com/gh/giantswarm/e2e-harness/2093?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link

Error is:
```
pkg/release/release.go:110:15: undefined: k8sClient
pkg/release/release.go:111:15: undefined: c
pkg/release/release.go:129:21: config.FileLogger undefined (type Config has no field or method FileLogger)
```

I spot it because I ran the test on my local machine w/o `-v` option.
And this is relatively small project.

JUnit report wasn't helpful. I think because:
```
2018/10/25 06:18:29 generating Junit report at: /tmp/results/golang/results.xml
2018/10/25 06:18:29 could not execute workflow: <nil>
```