### PR TITLE
fix go 1.11 builds

### DIFF
--- a/workflow/golang.go
+++ b/workflow/golang.go
@@ -245,7 +245,7 @@ func NewGoBuildTask(fs afero.Fs, projectInfo ProjectInfo) (tasks.Task, error) {
 				fmt.Sprintf("GOARCH=%v", projectInfo.Goarch),
 				"GOCACHE=/go/cache",
 				"GOPATH=/go",
-				"CGOENABLED=0",
+				"CGO_ENABLED=0",
 			},
 			WorkingDirectory: fmt.Sprintf(
 				"/go/src/github.com/%v/%v",
@@ -257,9 +257,8 @@ func NewGoBuildTask(fs afero.Fs, projectInfo ProjectInfo) (tasks.Task, error) {
 				"go", "build",
 				"-a",
 				"-v",
-				"-tags", "netgo",
 				"-ldflags", fmt.Sprintf(
-					"-w -X main.gitCommit=%s -linkmode 'external' -extldflags '-static'",
+					"-w -X main.gitCommit=%s -linkmode 'auto' -extldflags '-static'",
 					projectInfo.Sha,
 				),
 			},


### PR DESCRIPTION
* fix the CGO_ENABLED environment variable
* remove build tag netgo. Not necessary if CGO is disabled and default since 1.5 anyway.
* set linkmode to auto. External doesn't work in eg `retagger` or `ci-cleaner` projects. Failed with `loadinternal: cannot find runtime/cgo`. Internal discussion https://gigantic.slack.com/archives/C3C7ZQXC1/p1540656174012000