### PR TITLE
tasks: always remove docker containers

### DIFF
--- a/tasks/docker.go
+++ b/tasks/docker.go
@@ -1,9 +1,5 @@
 package tasks
 
-import (
-	"os"
-)
-
 type DockerTaskConfig struct {
 	Volumes          []string
 	Env              []string
@@ -15,14 +11,7 @@ type DockerTaskConfig struct {
 func NewDockerTask(name string, config DockerTaskConfig) ExecTask {
 	args := []string{
 		"docker", "run",
-	}
-
-	// CircleCI struggles with intermediate images, this helps to deal with that.
-	// See https://circleci.com/docs/docker/#deployment-to-a-docker-registry
-	if os.Getenv("CIRCLECI") == "true" {
-		args = append(args, "--rm=false")
-	} else {
-		args = append(args, "--rm")
+		"--rm",
 	}
 
 	for _, volume := range config.Volumes {

--- a/tasks/docker_test.go
+++ b/tasks/docker_test.go
@@ -1,7 +1,6 @@
 package tasks
 
 import (
-	"os"
 	"reflect"
 	"testing"
 )
@@ -9,7 +8,6 @@ import (
 func TestNewDockerTask(t *testing.T) {
 	tests := []struct {
 		config       DockerTaskConfig
-		inCircle     bool
 		expectedArgs []string
 	}{
 		// Test a simple docker task is constructed correctly
@@ -25,7 +23,6 @@ func TestNewDockerTask(t *testing.T) {
 				Image:            "golang:1.7.5",
 				Args:             []string{"go", "test"},
 			},
-			inCircle: false,
 			expectedArgs: []string{
 				"docker", "run", "--rm",
 				"-v", "/home/ubuntu/architect:/go/src/github.com/giantswarm/architect",
@@ -35,44 +32,9 @@ func TestNewDockerTask(t *testing.T) {
 				"go", "test",
 			},
 		},
-
-		// Test a similar config, but running in circle
-		{
-			config: DockerTaskConfig{
-				Volumes: []string{
-					"/home/ubuntu/architect:/go/src/github.com/giantswarm/architect",
-				},
-				Env: []string{
-					"GOOS=linux",
-				},
-				WorkingDirectory: "/go/src/github.com/giantswarm/architect",
-				Image:            "golang:1.7.5",
-				Args:             []string{"go", "test", "-v"},
-			},
-			inCircle: true,
-			expectedArgs: []string{
-				"docker", "run", "--rm=false",
-				"-v", "/home/ubuntu/architect:/go/src/github.com/giantswarm/architect",
-				"-e", "GOOS=linux",
-				"-w", "/go/src/github.com/giantswarm/architect",
-				"golang:1.7.5",
-				"go", "test", "-v",
-			},
-		},
 	}
 
 	for index, test := range tests {
-		// Configure circle env vars if needed
-		if test.inCircle {
-			if err := os.Setenv("CIRCLECI", "true"); err != nil {
-				t.Fatalf("could not set circle env var: %v", err)
-			}
-		} else {
-			if err := os.Setenv("CIRCLECI", ""); err != nil {
-				t.Fatalf("could not unset circle env var: %v", err)
-			}
-		}
-
 		testTask := NewDockerTask("test-task", test.config)
 
 		if !reflect.DeepEqual(test.expectedArgs, testTask.Args) {


### PR DESCRIPTION
Not sure what the issue was about. The URL in the comment gives 404.
I found this snippet (from
https://circleci.com/docs/2.0/building-docker-images/):

	- run: |
	    # start container with the application
	        # make sure you're not using `--rm` option otherwise the
	        container will be killed after finish
	            docker run --name app app-image:1.2.3

It looks like they are now fine with using --rm.