### PR TITLE
Remove cloudwatch-exporter from architect events

### DIFF
--- a/events/events.go
+++ b/events/events.go
@@ -40,10 +40,6 @@ var (
 	awsBaseProjectList = append(baseProjectList,
 		"aws-operator",
 	)
-	// aws project list + aws specific services
-	awsProjectList = append(awsBaseProjectList,
-		"g8s-cloudwatch-exporter",
-	)
 	// azure project list + azure specific services
 	azureProjectList = append(baseProjectList,
 		"azure-operator",


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/3609

cloudwatch exporter is being removed everywhere