### PR TITLE
Fail builds if DCO or LICENSE files are missing

### DIFF
--- a/DCO
+++ b/DCO
@@ -1,0 +1,36 @@
+Developer Certificate of Origin
+Version 1.1
+
+Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
+660 York Street, Suite 102,
+San Francisco, CA 94110 USA
+
+Everyone is permitted to copy and distribute verbatim copies of this
+license document, but changing it is not allowed.
+
+
+Developer's Certificate of Origin 1.1
+
+By making a contribution to this project, I certify that:
+
+(a) The contribution was created in whole or in part by me and I
+    have the right to submit it under the open source license
+    indicated in the file; or
+
+(b) The contribution is based upon previous work that, to the best
+    of my knowledge, is covered under an appropriate open source
+    license and I have the right under that license to submit that
+    work with modifications, whether created in whole or in part
+    by me, under the same open source license (unless I am
+    permitted to submit under a different license), as indicated
+    in the file; or
+
+(c) The contribution was provided directly to me by some other
+    person who certified (a), (b) or (c) and I have not modified
+    it.
+
+(d) I understand and agree that this project and the contribution
+    are public and that a record of the contribution (including all
+    personal information I submit with it, including my sign-off) is
+    maintained indefinitely and may be redistributed consistent with
+    this project or the open source license(s) involved.

--- a/workflow/error.go
+++ b/workflow/error.go
@@ -210,3 +210,12 @@ var invalidHelmDirectoryError = &microerror.Error{
 func IsInvalidHelmDirectory(err error) bool {
 	return microerror.Cause(err) == invalidHelmDirectoryError
 }
+
+var missingFileError = &microerror.Error{
+	Kind: "missingFileError",
+}
+
+// IsMissingFileError asserts missingFileError.
+func IsMissingFileError(err error) bool {
+	return microerror.Cause(err) == missingFileError
+}

--- a/workflow/repo.go
+++ b/workflow/repo.go
@@ -1,0 +1,47 @@
+package workflow
+
+import (
+	"fmt"
+
+	"github.com/giantswarm/microerror"
+	"github.com/spf13/afero"
+)
+
+const (
+	RepoCheckTaskName = "repo-check"
+)
+
+type RepoCheckTask struct {
+	fs afero.Fs
+}
+
+func (t RepoCheckTask) Name() string {
+	return RepoCheckTaskName
+}
+
+func (t RepoCheckTask) Run() error {
+	requiredFiles := []string{"DCO", "LICENSE"}
+
+	for _, requiredFile := range requiredFiles {
+		if _, err := t.fs.Stat(requiredFile); err != nil {
+			fmt.Printf("repo does not have required file '%s', see https://github.com/giantswarm/example-opensource-repo\n", requiredFile)
+			return microerror.Maskf(missingFileError, requiredFile)
+		}
+
+		fmt.Printf("repo has required file '%s'\n", requiredFile)
+	}
+
+	return nil
+}
+
+func (t RepoCheckTask) String() string {
+	return RepoCheckTaskName
+}
+
+func NewRepoCheckTask(fs afero.Fs, projectInfo ProjectInfo) (RepoCheckTask, error) {
+	t := RepoCheckTask{
+		fs: fs,
+	}
+
+	return t, nil
+}

--- a/workflow/workflow.go
+++ b/workflow/workflow.go
@@ -60,6 +60,12 @@ func NewBuild(projectInfo ProjectInfo, fs afero.Fs) (Workflow, error) {
 		return w, nil
 	}
 
+	repoCheckTask, err := NewRepoCheckTask(fs, projectInfo)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+	w = append(w, repoCheckTask)
+
 	isGolangFilesExist, err := golangFilesExist(fs, projectInfo.WorkingDirectory)
 	if err != nil {
 		return nil, microerror.Mask(err)

--- a/workflow/workflow_test.go
+++ b/workflow/workflow_test.go
@@ -86,7 +86,7 @@ func TestGetBuildWorkflow(t *testing.T) {
 		expectedTaskNames []string
 		errorMatcher      func(error) bool
 	}{
-		// Test 0 that a project with no files produces an empty workflow.
+		// Test 0 that a project with no files produces a workflow with just the repo check.
 		{
 			setUp: func(fs afero.Fs, testDir string) error {
 				projectInfo.WorkingDirectory = testDir
@@ -96,7 +96,9 @@ func TestGetBuildWorkflow(t *testing.T) {
 				}
 				return nil
 			},
-			expectedTaskNames: []string{},
+			expectedTaskNames: []string{
+				RepoCheckTaskName,
+			},
 		},
 
 		// Test 1 that a project with only golang files produces a correct workflow.
@@ -110,6 +112,7 @@ func TestGetBuildWorkflow(t *testing.T) {
 				return nil
 			},
 			expectedTaskNames: []string{
+				RepoCheckTaskName,
 				GoPullTaskName,
 				strings.Join([]string{
 					GoFmtTaskName,
@@ -133,6 +136,7 @@ func TestGetBuildWorkflow(t *testing.T) {
 				return nil
 			},
 			expectedTaskNames: []string{
+				RepoCheckTaskName,
 				GoPullTaskName,
 				strings.Join([]string{
 					GoFmtTaskName,
@@ -155,6 +159,7 @@ func TestGetBuildWorkflow(t *testing.T) {
 				return nil
 			},
 			expectedTaskNames: []string{
+				RepoCheckTaskName,
 				GoPullTaskName,
 				strings.Join([]string{
 					GoFmtTaskName,
@@ -175,6 +180,7 @@ func TestGetBuildWorkflow(t *testing.T) {
 				return nil
 			},
 			expectedTaskNames: []string{
+				RepoCheckTaskName,
 				GoPullTaskName,
 				strings.Join([]string{
 					GoFmtTaskName,
@@ -195,6 +201,7 @@ func TestGetBuildWorkflow(t *testing.T) {
 				return nil
 			},
 			expectedTaskNames: []string{
+				RepoCheckTaskName,
 				DockerBuildTaskName,
 				DockerLoginTaskName,
 				DockerPushShaTaskName,
@@ -216,6 +223,7 @@ func TestGetBuildWorkflow(t *testing.T) {
 				return nil
 			},
 			expectedTaskNames: []string{
+				RepoCheckTaskName,
 				GoPullTaskName,
 				strings.Join([]string{
 					GoFmtTaskName,
@@ -247,6 +255,7 @@ func TestGetBuildWorkflow(t *testing.T) {
 				return nil
 			},
 			expectedTaskNames: []string{
+				RepoCheckTaskName,
 				HelmPullTaskName,
 				HelmLoginTaskName,
 				template.TemplateHelmChartTaskName,
@@ -272,6 +281,7 @@ func TestGetBuildWorkflow(t *testing.T) {
 				return nil
 			},
 			expectedTaskNames: []string{
+				RepoCheckTaskName,
 				DockerBuildTaskName,
 				DockerLoginTaskName,
 				DockerPushShaTaskName,
@@ -327,6 +337,7 @@ func TestGetBuildWorkflow(t *testing.T) {
 				return nil
 			},
 			expectedTaskNames: []string{
+				RepoCheckTaskName,
 				GoPullTaskName,
 				strings.Join([]string{
 					GoFmtTaskName,


### PR DESCRIPTION
Closes https://github.com/giantswarm/giantswarm/issues/5029

This will apply to *all* repos that `architect` builds, but I think having a switch based on public/private isn't necessary - if we should do it for public repos, we should do it for private repos too.