### PR TITLE
Remove endpoint-operator from kvmProjectList

### DIFF
--- a/events/events.go
+++ b/events/events.go
@@ -46,7 +46,6 @@ var (
 	)
 	// kvm project list + kvm specific services
 	kvmProjectList = append(baseProjectList,
-		"endpoint-operator",
 		"flannel-operator",
 		"kvm-operator",
 	)


### PR DESCRIPTION
Endpoint-operator is nowadays part of kvm-operator and not used as independent
operator. Therefore there's no point in following it by architect either.