### PR TITLE
 Add check for license text format

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2017 Giant Swarm GmbH
+   Copyright 2016 - 2019 Giant Swarm GmbH
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/workflow/error.go
+++ b/workflow/error.go
@@ -219,3 +219,12 @@ var missingFileError = &microerror.Error{
 func IsMissingFileError(err error) bool {
 	return microerror.Cause(err) == missingFileError
 }
+
+var missingLicenseTextError = &microerror.Error{
+	Kind: "missingLicenseText",
+}
+
+// IsMissingLicenseText asserts missingLicenseTextError.
+func IsMissingLicenseTextError(err error) bool {
+	return microerror.Cause(err) == missingLicenseTextError
+}

--- a/workflow/error.go
+++ b/workflow/error.go
@@ -148,6 +148,15 @@ func IsEmptyGolangVersion(err error) bool {
 	return microerror.Cause(err) == emptyGolangVersionError
 }
 
+var failedExecutionError = &microerror.Error{
+	Kind: "failedExecutionError",
+}
+
+// IsFailedExecution asserts failedExecutionError.
+func IsFailedExecutionError(err error) bool {
+	return microerror.Cause(err) == failedExecutionError
+}
+
 var noHelmDirectoryError = &microerror.Error{
 	Kind: "noHelmDirectoryError",
 }
@@ -218,13 +227,4 @@ var missingFileError = &microerror.Error{
 // IsMissingFileError asserts missingFileError.
 func IsMissingFileError(err error) bool {
 	return microerror.Cause(err) == missingFileError
-}
-
-var missingLicenseTextError = &microerror.Error{
-	Kind: "missingLicenseText",
-}
-
-// IsMissingLicenseText asserts missingLicenseTextError.
-func IsMissingLicenseTextError(err error) bool {
-	return microerror.Cause(err) == missingLicenseTextError
 }

--- a/workflow/repo.go
+++ b/workflow/repo.go
@@ -74,7 +74,7 @@ func (t RepoCheckTask) checkLicenseText() error {
 	license := string(l)
 	if !strings.Contains(license, licenseText) {
 		fmt.Printf("repo '%s' file does not contain required text '%s'\n", licenseFileName, licenseText)
-		return microerror.Maskf(missingLicenseTextError, licenseText)
+		return microerror.Maskf(failedExecutionError, "license does not contain text '%s'", licenseText)
 	}
 
 	fmt.Printf("repo '%s' has required text '%s'\n", licenseFileName, licenseText)

--- a/workflow/repo.go
+++ b/workflow/repo.go
@@ -12,8 +12,14 @@ import (
 const (
 	RepoCheckTaskName = "repo-check"
 
-	// licenseTextFormat is used to generate the license text so the format can
-	// be checked.
+	// dcoFileName is the name of the Developer Certificate of Origin file.
+	dcoFileName = "DCO"
+
+	// licenseFileName is the name of the License file.
+	licenseFileName = "LICENSE"
+
+	// licenseTextFormat generates the license text so the format can be
+	// checked.
 	licenseTextFormat = "Copyright 2016 - %d Giant Swarm GmbH"
 )
 
@@ -26,7 +32,7 @@ func (t RepoCheckTask) Name() string {
 }
 
 func (t RepoCheckTask) Run() error {
-	requiredFiles := []string{"DCO", "LICENSE"}
+	requiredFiles := []string{dcoFileName, licenseFileName}
 
 	for _, requiredFile := range requiredFiles {
 		if _, err := t.fs.Stat(requiredFile); err != nil {
@@ -60,15 +66,18 @@ func NewRepoCheckTask(fs afero.Fs, projectInfo ProjectInfo) (RepoCheckTask, erro
 func (t RepoCheckTask) checkLicenseText() error {
 	licenseText := fmt.Sprintf(licenseTextFormat, time.Now().Year())
 
-	l, err := afero.ReadFile(t.fs, "LICENSE")
+	l, err := afero.ReadFile(t.fs, licenseFileName)
 	if err != nil {
 		return microerror.Mask(err)
 	}
 
 	license := string(l)
 	if !strings.Contains(license, licenseText) {
-		return microerror.Maskf(missingLicenseTextError, "LICENSE file does not contain text %#q", licenseText)
+		fmt.Printf("repo '%s' file does not contain required text '%s'\n", licenseFileName, licenseText)
+		return microerror.Maskf(missingLicenseTextError, licenseText)
 	}
+
+	fmt.Printf("repo '%s' has required text '%s'\n", licenseFileName, licenseText)
 
 	return nil
 }


### PR DESCRIPTION
Fixes https://github.com/giantswarm/giantswarm/issues/5094

Checks the text is correct based on https://github.com/giantswarm/example-opensource-repo/blob/5badb5cac85bf9a0177ec06c16e2ac42f63f7ac6/LICENSE#L189.

Output if the check fails.

```
2019/01/29 13:11:25 running task: repo-check
repo has required file 'DCO'
repo has required file 'LICENSE'
repo 'LICENSE' file does not contain required text 'Copyright 2016 - 2019 Giant Swarm GmbH'
```

Output if the check passes.

```
2019/01/29 13:13:09 running task: repo-check
repo has required file 'DCO'
repo has required file 'LICENSE'
repo 'LICENSE' has required text 'Copyright 2016 - 2019 Giant Swarm GmbH'
```

