### PR TITLE
set git commit SHA in pkg/project.gitSHA

### DIFF
--- a/workflow/golang.go
+++ b/workflow/golang.go
@@ -258,8 +258,10 @@ func NewGoBuildTask(fs afero.Fs, projectInfo ProjectInfo) (tasks.Task, error) {
 				"-a",
 				"-v",
 				"-ldflags", fmt.Sprintf(
-					"-w -X main.gitCommit=%s -linkmode 'auto' -extldflags '-static'",
+					"-w -X main.gitCommit=%s -X github.com/%s/%s/pkg/project.gitSHA=%[1]s -linkmode 'auto' -extldflags '-static'",
 					projectInfo.Sha,
+					projectInfo.Organisation,
+					projectInfo.Project,
 				),
 			},
 		},


### PR DESCRIPTION
Towrads: https://github.com/giantswarm/giantswarm/issues/5371
Follow up: https://github.com/giantswarm/release-operator/pull/50

We introduce the new `pkg/project` package in release-operator, which regroup project wide information like git sha, project name, etc.

Architect now needs to update the git sha, in the `pkg/project` package instead of `main`.