### PR TITLE
Add app-operator to the project list

### DIFF
--- a/events/events.go
+++ b/events/events.go
@@ -13,6 +13,7 @@ var (
 	// services used in all our installations
 	baseProjectList = []string{
 		"api",
+		"app-operator",
 		"cert-exporter",
 		"cert-operator",
 		"chart-operator",


### PR DESCRIPTION
Now we have e2e in place we should install app-operator in control plane clusters so we can start integration testing.