### PR TITLE
Add a way to create deployment events for only a specific group of testing environments.

### DIFF
--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -23,6 +23,7 @@ var (
 	}
 
 	deploymentEventsToken string
+	group                 string
 )
 
 func init() {
@@ -42,6 +43,7 @@ func init() {
 	deployCmd.Flags().StringVar(&dockerPassword, "docker-password", defaultDockerPassword, "password to use to login to docker registry")
 
 	deployCmd.Flags().StringVar(&helmDirectoryPath, "helm-directory-path", "./helm", "directory holding helm chart")
+	deployCmd.Flags().StringVar(&group, "group", "stable", "the group you want to create deployment events for. Can be 'stable' or 'testing'")
 }
 
 func runDeploy(cmd *cobra.Command, args []string) {
@@ -91,7 +93,7 @@ func runDeploy(cmd *cobra.Command, args []string) {
 	githubClient := github.NewClient(tc)
 
 	log.Printf("creating deployment events")
-	environments := events.GetEnvironments(project)
+	environments := events.GetEnvironments(project, group)
 
 	log.Printf("creating for environments: %v", environments)
 	for _, environment := range environments {

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -43,7 +43,7 @@ func init() {
 	deployCmd.Flags().StringVar(&dockerPassword, "docker-password", defaultDockerPassword, "password to use to login to docker registry")
 
 	deployCmd.Flags().StringVar(&helmDirectoryPath, "helm-directory-path", "./helm", "directory holding helm chart")
-	deployCmd.Flags().StringVar(&group, "group", "stable", "the group you want to create deployment events for. Can be 'stable' or 'testing'")
+	deployCmd.Flags().StringVar(&group, "group", "all", "the group you want to create deployment events for. Can be 'all' or 'testing'")
 }
 
 func runDeploy(cmd *cobra.Command, args []string) {

--- a/events/events.go
+++ b/events/events.go
@@ -103,12 +103,42 @@ var environmentProjects = map[Environment][]string{
 	},
 }
 
+// testingGroup is a specific grouping of environments that are considered
+// testing environments.
+var testingGroup = []Environment{
+	"gauss",
+	"geckon",
+	"ghost",
+	"ginger",
+	"giraffe",
+	"godsmack",
+	"gorgoth",
+}
+
+// isTestingEnvironment checks if a given environment is in the testingGroup.
+func isTestingEnvironment(environment Environment) bool {
+	for _, testEnvironment := range testingGroup {
+		if environment == testEnvironment {
+			return true
+		}
+	}
+
+	return false
+}
+
 // GetEnvironments takes a project name, and returns a list of environments
-// where this project should be deployed to.
-func GetEnvironments(project string) []Environment {
+// where this project should be deployed to. If group is 'testing', then it
+// only considers environments in the testingGroup.
+func GetEnvironments(project string, group string) []Environment {
 	environments := []Environment{}
 
 	for environment, projects := range environmentProjects {
+		// Skip environments that are not testing environments
+		// if we are requesting deploys to the testing group
+		if group == "testing" && !isTestingEnvironment(environment) {
+			continue
+		}
+
 		for _, p := range projects {
 			if project == p {
 				environments = append(environments, environment)


### PR DESCRIPTION
This should allow me to do: `architect deploy --group=testing` in CI, to conditionally deploy to only our testing environments.