### PR TITLE
release command

### DIFF
--- a/cmd/release.go
+++ b/cmd/release.go
@@ -42,8 +42,7 @@ func runRelease(cmd *cobra.Command, args []string) {
 	var githubClient *github.Client
 	{
 		if deploymentEventsToken == "" {
-			log.Printf("no github token")
-			return
+			log.Fatalf("no github token")
 		}
 
 		ts := oauth2.StaticTokenSource(

--- a/cmd/release.go
+++ b/cmd/release.go
@@ -1,0 +1,70 @@
+package cmd
+
+import (
+	"context"
+	"log"
+
+	"github.com/google/go-github/github"
+	"github.com/spf13/afero"
+	"github.com/spf13/cobra"
+	"golang.org/x/oauth2"
+
+	"github.com/giantswarm/architect/tasks"
+	"github.com/giantswarm/architect/workflow"
+)
+
+var (
+	releaseCmd = &cobra.Command{
+		Use:   "release",
+		Short: "release chart as github release",
+		Run:   runRelease,
+	}
+)
+
+func init() {
+	RootCmd.AddCommand(releaseCmd)
+}
+
+func runRelease(cmd *cobra.Command, args []string) {
+	fs := afero.NewOsFs()
+
+	projectInfo := workflow.ProjectInfo{
+		WorkingDirectory: workingDirectory,
+		Organisation:     organisation,
+		Project:          project,
+
+		Sha: sha,
+		Tag: tag,
+	}
+
+	var githubClient *github.Client
+	{
+		if deploymentEventsToken == "" {
+			log.Printf("no github token")
+			return
+		}
+
+		ctx := context.Background()
+		ts := oauth2.StaticTokenSource(
+			&oauth2.Token{AccessToken: deploymentEventsToken},
+		)
+		tc := oauth2.NewClient(ctx, ts)
+		githubClient = github.NewClient(tc)
+	}
+
+	workflow, err := workflow.NewRelease(projectInfo, fs, githubClient)
+	if err != nil {
+		log.Fatalf("could not get workflow: %v", err)
+	}
+
+	log.Printf("running workflow: %s\n", workflow)
+
+	if dryRun {
+		log.Printf("dry run, not actually running workflow")
+		return
+	}
+
+	if err := tasks.Run(workflow); err != nil {
+		log.Fatalf("could not execute workflow: %v", err)
+	}
+}

--- a/cmd/release.go
+++ b/cmd/release.go
@@ -26,6 +26,8 @@ func init() {
 }
 
 func runRelease(cmd *cobra.Command, args []string) {
+	ctx := context.Background()
+
 	fs := afero.NewOsFs()
 
 	projectInfo := workflow.ProjectInfo{
@@ -44,7 +46,6 @@ func runRelease(cmd *cobra.Command, args []string) {
 			return
 		}
 
-		ctx := context.Background()
 		ts := oauth2.StaticTokenSource(
 			&oauth2.Token{AccessToken: deploymentEventsToken},
 		)

--- a/release/task.go
+++ b/release/task.go
@@ -12,33 +12,19 @@ const (
 )
 
 type ReleaseGithubTask struct {
-	Client       *github.Client
-	Dir          string
+	Client *github.Client
+
+	AssetsDir    string
+	Draft        bool
 	Organisation string
 	Project      string
 	Sha          string
 	Tag          string
 }
 
-func NewReleaseGithubTaskclient(client *github.Client) ReleaseGithubTask {
-	task := ReleaseGithubTask{
-		Client: client,
-	}
-
-	return task
-}
-
-// Run creates a draft github release.
+// Run ensures a github release.
 func (r ReleaseGithubTask) Run() error {
-	info := releaseInfo{
-		AssetsDir:    r.Dir,
-		Draft:        true,
-		Organisation: r.Organisation,
-		Project:      r.Project,
-		Sha:          r.Sha,
-		Tag:          r.Tag,
-	}
-	return ensureWithDir(r.Client, info)
+	return r.ensureWithDir()
 }
 
 func (r ReleaseGithubTask) Name() string {

--- a/release/task.go
+++ b/release/task.go
@@ -20,6 +20,14 @@ type ReleaseGithubTask struct {
 	Tag          string
 }
 
+func NewReleaseGithubTaskclient(client *github.Client) ReleaseGithubTask {
+	task := ReleaseGithubTask{
+		Client: client,
+	}
+
+	return task
+}
+
 // Run creates a draft github release.
 func (r ReleaseGithubTask) Run() error {
 	info := releaseInfo{

--- a/workflow/github.go
+++ b/workflow/github.go
@@ -16,7 +16,7 @@ func NewReleaseGithubTask(client *github.Client, dir string, projectInfo Project
 
 	githubRelease := release.ReleaseGithubTask{
 		Client:       client,
-		Dir:          dir,
+		AssetsDir:    dir,
 		Organisation: projectInfo.Organisation,
 		Project:      projectInfo.Project,
 		Sha:          projectInfo.Sha,

--- a/workflow/workflow.go
+++ b/workflow/workflow.go
@@ -305,8 +305,10 @@ func NewRelease(projectInfo ProjectInfo, fs afero.Fs, githubClient *github.Clien
 		w = append(w, helmChartPackage)
 
 		githubRelease := release.ReleaseGithubTask{
-			Client:       githubClient,
-			Dir:          tmpDir,
+			Client: githubClient,
+
+			AssetsDir:    tmpDir,
+			Draft:        true,
 			Organisation: projectInfo.Organisation,
 			Project:      projectInfo.Project,
 			Sha:          projectInfo.Sha,

--- a/workflow/workflow.go
+++ b/workflow/workflow.go
@@ -294,7 +294,7 @@ func NewRelease(projectInfo ProjectInfo, fs afero.Fs, githubClient *github.Clien
 		return nil, microerror.Mask(err)
 	}
 
-	if chartDirectoryExists {
+	if chartDirectoryExists && projectInfo.Tag != "" {
 		helmChartTemplate, err := NewTemplateHelmChartTask(fs, chartDirectory, projectInfo)
 		if err != nil {
 			return nil, microerror.Mask(err)


### PR DESCRIPTION
Towards: [giantswarm/giantswarm#5206](https://github.com/giantswarm/giantswarm/issues/5206)

Provide a new `architect release` command which does the following:
- template the chart
- package it as an archive
- create a draft github release with the chart uploaded as asset