### PR TITLE
add version

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -67,6 +67,8 @@ func runBuild(cmd *cobra.Command, args []string) {
 		Sha:    sha,
 		Tag:    tag,
 
+		Version: version,
+
 		Registry:       registry,
 		DockerUsername: dockerUsername,
 		DockerPassword: dockerPassword,

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -58,6 +58,8 @@ func runDeploy(cmd *cobra.Command, args []string) {
 		Sha:    sha,
 		Tag:    tag,
 
+		Version: version,
+
 		Registry:       registry,
 		DockerUsername: dockerUsername,
 		DockerPassword: dockerPassword,

--- a/cmd/publish.go
+++ b/cmd/publish.go
@@ -73,6 +73,8 @@ func runPublish(cmd *cobra.Command, args []string) {
 		Sha:    sha,
 		Tag:    tag,
 
+		Version: version,
+
 		Registry:       registry,
 		DockerUsername: dockerUsername,
 		DockerPassword: dockerPassword,

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -81,7 +81,7 @@ func init() {
 	{
 		// version can be of three different formats:
 		//   v1.0.0: building a tagged version.
-		//   v1.0.0+git: building ahead of a tagged version.
+		//   v1.0.0-3a955cbb126f0fe5d51aedf2eb84acca7b074374: building ahead of a tagged version.
 		//   v0.0.0-939f5c6949f83c0a7ea98a25bc9524fd2f751ffe: building a repo which has no tags.
 		if tag != "" {
 			version = tag
@@ -91,7 +91,7 @@ func init() {
 				log.Fatalf("could not get git branch: %#v\n", err)
 				version = fmt.Sprintf("v0.0.0-%s", defaultSha)
 			} else {
-				version = fmt.Sprintf("%s+git", strings.TrimSpace(string(out)))
+				version = fmt.Sprintf("%s-%s", strings.TrimSpace(string(out)), defaultSha)
 			}
 
 		}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -69,12 +69,14 @@ func init() {
 		}
 	}
 
-	// Use git tag when available.
+	// We also use the git HEAD branch as well.
+	var defaultBranch string
 	{
-		out, err := exec.Command("git", "describe", "--tags", "--exact-match", "HEAD").Output()
-		if err == nil {
-			version = strings.TrimSpace(string(out))
+		out, err := exec.Command("git", "rev-parse", "--abbrev-ref", "HEAD").Output()
+		if err != nil {
+			log.Fatalf("could not get git branch: %#v\n", err)
 		}
+		defaultBranch = strings.TrimSpace(string(out))
 	}
 
 	// Define the version we are building.

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -90,7 +90,6 @@ func init() {
 		} else {
 			out, err := exec.Command("git", "describe", "--tags", "--abbrev=0", "HEAD").Output()
 			if err != nil {
-				log.Fatalf("could not get git branch: %#v\n", err)
 				version = fmt.Sprintf("v0.0.0-%s", defaultSha)
 			} else {
 				version = fmt.Sprintf("%s-%s", strings.TrimSpace(string(out)), defaultSha)

--- a/cmd/unpublish.go
+++ b/cmd/unpublish.go
@@ -51,6 +51,8 @@ func runUnpublish(cmd *cobra.Command, args []string) {
 		Sha:    sha,
 		Tag:    tag,
 
+		Version: version,
+
 		Registry:       registry,
 		DockerUsername: dockerUsername,
 		DockerPassword: dockerPassword,

--- a/workflow/workflow.go
+++ b/workflow/workflow.go
@@ -36,6 +36,8 @@ type ProjectInfo struct {
 	Sha    string
 	Tag    string
 
+	Version string
+
 	Registry       string
 	DockerUsername string
 	DockerPassword string


### PR DESCRIPTION
Towards: [giantswarm/giantswarm#5206](https://github.com/giantswarm/giantswarm/issues/5206)
Towards: https://github.com/giantswarm/giantswarm/issues/5371

From [voo spec](https://github.com/giantswarm/giantswarm/blob/master/specs/versioning-of-operators.md#ci):
> - Version tag is injected into the "version" variable in package "./pkg/project" during build time.
>     - When the tag is not set for the commit the variable is set to the latest tag in the branch with "+git" suffix. E.g. "v1.2.0+git".

This PR adds version detection to architect.