### PR TITLE
add release workflow

### DIFF
--- a/workflow/github.go
+++ b/workflow/github.go
@@ -11,7 +11,7 @@ import (
 func NewReleaseGithubTask(client *github.Client, dir string, projectInfo ProjectInfo) (tasks.Task, error) {
 	err := checkReleaseRequirements(projectInfo)
 	if err != nil {
-		microerror.Mask(err)
+		return nil, microerror.Mask(err)
 	}
 
 	githubRelease := release.ReleaseGithubTask{

--- a/workflow/pack.go
+++ b/workflow/pack.go
@@ -6,7 +6,7 @@ import (
 	"github.com/spf13/afero"
 )
 
-// NewPackageHelmChartTaskCreator returns a closure whith pre-defined dst directory.
+// NewPackageHelmChartTaskCreator returns a closure with pre-defined dst directory.
 //
 // This is usefull when used with processHelmDir.
 func NewPackageHelmChartTaskCreator(dst string) func(afero.Fs, string, ProjectInfo) (tasks.Task, error) {

--- a/workflow/pack.go
+++ b/workflow/pack.go
@@ -1,0 +1,16 @@
+package workflow
+
+import (
+	"github.com/giantswarm/architect/pack"
+	"github.com/giantswarm/architect/tasks"
+	"github.com/spf13/afero"
+)
+
+// NewPackageHelmChartTaskCreator returns a closure whith pre-defined dst directory.
+//
+// This is usefull when used with processHelmDir.
+func NewPackageHelmChartTaskCreator(dst string) func(afero.Fs, string, ProjectInfo) (tasks.Task, error) {
+	return func(fs afero.Fs, chartDir string, projectInfo ProjectInfo) (tasks.Task, error) {
+		return pack.NewPackageHelmChartTask(chartDir, dst), nil
+	}
+}


### PR DESCRIPTION
Towards: giantswarm/giantswarm#5206

Add the github release workflow:
- template charts
- package charts (yes there is mutliple chart support now)
- create github release