### PR TITLE
add release command

### DIFF
--- a/cmd/release.go
+++ b/cmd/release.go
@@ -1,0 +1,87 @@
+package cmd
+
+import (
+	"context"
+	"io/ioutil"
+	"log"
+	"os"
+
+	"github.com/google/go-github/github"
+	"github.com/spf13/afero"
+	"github.com/spf13/cobra"
+	"golang.org/x/oauth2"
+
+	"github.com/giantswarm/architect/tasks"
+	"github.com/giantswarm/architect/workflow"
+)
+
+var (
+	releaseCmd = &cobra.Command{
+		Use:   "release",
+		Short: "release chart as github release",
+		Run:   runRelease,
+	}
+)
+
+func init() {
+	RootCmd.AddCommand(releaseCmd)
+}
+
+func runRelease(cmd *cobra.Command, args []string) {
+	var err error
+
+	ctx := context.Background()
+
+	fs := afero.NewOsFs()
+
+	projectInfo := workflow.ProjectInfo{
+		WorkingDirectory: workingDirectory,
+		Organisation:     organisation,
+		Project:          project,
+
+		Sha: sha,
+		Tag: tag,
+
+		Version: version,
+	}
+
+	var githubClient *github.Client
+	{
+		if deploymentEventsToken == "" {
+			log.Fatalf("no github token")
+		}
+
+		ts := oauth2.StaticTokenSource(
+			&oauth2.Token{AccessToken: deploymentEventsToken},
+		)
+		tc := oauth2.NewClient(ctx, ts)
+		githubClient = github.NewClient(tc)
+	}
+
+	var releaseDir string
+	{
+		releaseDir, err = ioutil.TempDir(os.TempDir(), "architect-release")
+		if err != nil {
+			log.Fatalf("could not create release dir: %v", err)
+		}
+		defer os.RemoveAll(releaseDir)
+	}
+
+	{
+		workflow, err := workflow.NewRelease(projectInfo, fs, releaseDir, githubClient)
+		if err != nil {
+			log.Fatalf("could not get workflow: %v", err)
+		}
+
+		log.Printf("running workflow: %s\n", workflow)
+
+		if dryRun {
+			log.Printf("dry run, not actually running workflow")
+			return
+		}
+
+		if err := tasks.Run(workflow); err != nil {
+			log.Fatalf("could not execute workflow: %v", err)
+		}
+	}
+}

--- a/cmd/release/command.go
+++ b/cmd/release/command.go
@@ -1,0 +1,13 @@
+package release
+
+import (
+	"github.com/spf13/cobra"
+)
+
+var (
+	Cmd = &cobra.Command{
+		Use:   "release",
+		Short: "release chart as github release",
+		RunE:  runReleaseError,
+	}
+)

--- a/cmd/release/error.go
+++ b/cmd/release/error.go
@@ -1,0 +1,29 @@
+package release
+
+import (
+	"github.com/giantswarm/microerror"
+)
+
+var missingGithubTokenError = &microerror.Error{
+	Kind: "missingGithubTokenError",
+}
+
+func IsMissingGithubTokenError(err error) bool {
+	return microerror.Cause(err) == missingGithubTokenError
+}
+
+var createReleaseDirError = &microerror.Error{
+	Kind: "createReleaseDirError",
+}
+
+func IsCreateReleaseDirError(err error) bool {
+	return microerror.Cause(err) == createReleaseDirError
+}
+
+var createWorkflowError = &microerror.Error{
+	Kind: "createWorkflowError",
+}
+
+func IsCreateWorkflowError(err error) bool {
+	return microerror.Cause(err) == createWorkflowError
+}

--- a/cmd/release/runner.go
+++ b/cmd/release/runner.go
@@ -17,13 +17,7 @@ import (
 )
 
 func runReleaseError(cmd *cobra.Command, args []string) error {
-	var err error
-
-	ctx := context.Background()
-
-	fs := afero.NewOsFs()
-
-	projectInfo := workflow.ProjectInfo{
+	var projectInfo = workflow.ProjectInfo{
 		WorkingDirectory: cmd.Flag("working-directory").Value.String(),
 		Organisation:     cmd.Flag("organisation").Value.String(),
 		Project:          cmd.Flag("project").Value.String(),
@@ -44,13 +38,14 @@ func runReleaseError(cmd *cobra.Command, args []string) error {
 		ts := oauth2.StaticTokenSource(
 			&oauth2.Token{AccessToken: githubToken},
 		)
+		ctx := context.Background()
 		tc := oauth2.NewClient(ctx, ts)
 		githubClient = github.NewClient(tc)
 	}
 
 	var releaseDir string
 	{
-		releaseDir, err = ioutil.TempDir(os.TempDir(), "architect-release")
+		releaseDir, err := ioutil.TempDir(os.TempDir(), "architect-release")
 		if err != nil {
 			return microerror.Mask(err)
 		}
@@ -58,6 +53,8 @@ func runReleaseError(cmd *cobra.Command, args []string) error {
 	}
 
 	{
+		fs := afero.NewOsFs()
+
 		workflow, err := workflow.NewRelease(projectInfo, fs, releaseDir, githubClient)
 		if err != nil {
 			return microerror.Mask(err)


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/5206

Provide `architect release` command, whenever a git tag is present, it creates a draft github release, with helm charts uploaded as assets.