### PR TITLE
fix tag and version propagation

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -116,9 +116,9 @@ func init() {
 
 	RootCmd.PersistentFlags().StringVar(&branch, "branch", defaultBranch, "git branch being built")
 	RootCmd.PersistentFlags().StringVar(&sha, "sha", defaultSha, "git SHA1 being built")
-	RootCmd.PersistentFlags().String("tag", defaultTag, "git tag being built")
+	RootCmd.PersistentFlags().StringVar(&tag, "tag", defaultTag, "git tag being built")
 
-	RootCmd.PersistentFlags().String("version", defaultVersion, "project version being built")
+	RootCmd.PersistentFlags().StringVar(&version, "version", defaultVersion, "project version being built")
 
 	RootCmd.PersistentFlags().BoolVar(&dryRun, "dry-run", dryRun, "show what would be executed, but take no action")
 


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/5206

Fixes an issue where `tag` and `version` where not correctly propagated in the `cmd` package.