### PR TITLE
support legacy version, trim v prefix

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -68,7 +68,7 @@ func init() {
 	{
 		out, err := exec.Command("git", "describe", "--tags", "--exact-match", "HEAD").Output()
 		if err == nil {
-			defaultTag = strings.TrimSpace(string(out))
+			defaultTag = strings.TrimPrefix(strings.TrimSpace(string(out)), "v")
 		}
 	}
 
@@ -86,17 +86,17 @@ func init() {
 	var defaultVersion string
 	{
 		// version can be of three different formats:
-		//   v1.0.0: building a tagged version.
-		//   v1.0.0-3a955cbb126f0fe5d51aedf2eb84acca7b074374: building ahead of a tagged version.
-		//   v0.0.0-939f5c6949f83c0a7ea98a25bc9524fd2f751ffe: building a repo which has no tags.
+		//   2.0.0: building a tagged version.
+		//   2.0.0-3a955cbb126f0fe5d51aedf2eb84acca7b074374: building ahead of a tagged version.
+		//   1.0.0-939f5c6949f83c0a7ea98a25bc9524fd2f751ffe: building a repo which has no tags.
 		if defaultTag != "" {
 			defaultVersion = defaultTag
 		} else {
 			out, err := exec.Command("git", "describe", "--tags", "--abbrev=0", "HEAD").Output()
 			if err != nil {
-				defaultVersion = fmt.Sprintf("v0.0.0-%s", defaultSha)
+				defaultVersion = fmt.Sprintf("1.0.0-%s", defaultSha)
 			} else {
-				defaultVersion = fmt.Sprintf("%s-%s", strings.TrimSpace(string(out)), defaultSha)
+				defaultVersion = fmt.Sprintf("%s-%s", strings.TrimPrefix(strings.TrimSpace(string(out)), "v"), defaultSha)
 			}
 
 		}


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/5206

In order to not introduce breaking changes, architect need to be able to continue building charts using the old `1.0.0-<sha>` version. Otherwise draughtman will break see https://github.com/giantswarm/azure-operator/pull/499#issuecomment-479013968.

Also remove the `v` prefix from the version being detected as helm charts do not support this. Additionally docker images tag are preferred to be without this prefix.