### PR TITLE
forgot the cmd/release/flag.go file

### DIFF
--- a/cmd/release/flag.go
+++ b/cmd/release/flag.go
@@ -1,0 +1,11 @@
+package release
+
+import "os"
+
+func init() {
+	defaultDockerUsername := os.Getenv("QUAY_USERNAME")
+	defaultDockerPassword := os.Getenv("QUAY_PASSWORD")
+
+	Cmd.Flags().String("docker-username", defaultDockerUsername, "username to use to login to docker registry")
+	Cmd.Flags().String("docker-password", defaultDockerPassword, "password to use to login to docker registry")
+}


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/5206

Forgot to add `cmd/release/flag.go` in previous PR.