### PR TITLE
only build tag on circleci when explicitly requested

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -68,7 +68,10 @@ func init() {
 	{
 		out, err := exec.Command("git", "describe", "--tags", "--exact-match", "HEAD").Output()
 		if err == nil {
-			defaultTag = strings.TrimPrefix(strings.TrimSpace(string(out)), "v")
+			// Always populate tag unless building on CircleCI and it is not explicitly requesting to build a tag.
+			if _, ciTagExists := os.LookupEnv("CIRCLE_TAG"); os.Getenv("CIRCLECI") != "true" || ciTagExists {
+				defaultTag = strings.TrimPrefix(strings.TrimSpace(string(out)), "v")
+			}
 		}
 	}
 


### PR DESCRIPTION
Towards: https://github.com/giantswarm/azure-operator/pull/499

Fixes an issue where `architect` is building tagged version even if CircleCI is requesting to build regular commit sha.

See https://circleci.com/gh/giantswarm/azure-operator/5229