### PR TITLE
circleci trigger-job: command structure

### DIFF
--- a/cmd/circleci/command.go
+++ b/cmd/circleci/command.go
@@ -2,6 +2,8 @@ package circleci
 
 import (
 	"github.com/spf13/cobra"
+
+	"github.com/giantswarm/architect/cmd/circleci/triggerjob"
 )
 
 var (
@@ -10,3 +12,7 @@ var (
 		Short: "interacts with CircleCI",
 	}
 )
+
+func init() {
+	Cmd.AddCommand(triggerjob.Cmd)
+}

--- a/cmd/circleci/command.go
+++ b/cmd/circleci/command.go
@@ -1,0 +1,12 @@
+package circleci
+
+import (
+	"github.com/spf13/cobra"
+)
+
+var (
+	Cmd = &cobra.Command{
+		Use:   "circleci",
+		Short: "interacts with CircleCI",
+	}
+)

--- a/cmd/circleci/triggerjob/command.go
+++ b/cmd/circleci/triggerjob/command.go
@@ -1,0 +1,13 @@
+package triggerjob
+
+import (
+	"github.com/spf13/cobra"
+)
+
+var (
+	Cmd = &cobra.Command{
+		Use:   "trigger-job",
+		Short: "Trigger a CircleCI job",
+		RunE:  runTriggerJobError,
+	}
+)

--- a/cmd/circleci/triggerjob/error.go
+++ b/cmd/circleci/triggerjob/error.go
@@ -1,0 +1,29 @@
+package triggerjob
+
+import (
+	"github.com/giantswarm/microerror"
+)
+
+var missingBranchError = &microerror.Error{
+	Kind: "missingBranchError",
+}
+
+func IsMissingBranchnError(err error) bool {
+	return microerror.Cause(err) == missingBranchError
+}
+
+var missingOrganisationError = &microerror.Error{
+	Kind: "missingOrganisationError",
+}
+
+func IsMissingOrganisationnError(err error) bool {
+	return microerror.Cause(err) == missingOrganisationError
+}
+
+var missingRepositoryError = &microerror.Error{
+	Kind: "missingRepositoryError",
+}
+
+func IsMissingRepositorynError(err error) bool {
+	return microerror.Cause(err) == missingRepositoryError
+}

--- a/cmd/circleci/triggerjob/flag.go
+++ b/cmd/circleci/triggerjob/flag.go
@@ -1,0 +1,9 @@
+package triggerjob
+
+func init() {
+	Cmd.Flags().String("token", "", "CircleCI API token")
+	Cmd.Flags().String("org", "", "CircleCI organization")
+	Cmd.Flags().String("repo", "", "CircleCI repository")
+	Cmd.Flags().String("branch", "master", "name of the repository branch")
+	Cmd.Flags().String("job", "", "CircleCI job")
+}

--- a/cmd/circleci/triggerjob/runner.go
+++ b/cmd/circleci/triggerjob/runner.go
@@ -1,0 +1,9 @@
+package triggerjob
+
+import (
+	"github.com/spf13/cobra"
+)
+
+func runTriggerJobError(cmd *cobra.Command, args []string) error {
+	return nil
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/giantswarm/architect/cmd/circleci"
 	"github.com/giantswarm/architect/cmd/release"
 )
 
@@ -125,5 +126,6 @@ func init() {
 
 	RootCmd.PersistentFlags().BoolVar(&dryRun, "dry-run", dryRun, "show what would be executed, but take no action")
 
+	RootCmd.AddCommand(circleci.Cmd)
 	RootCmd.AddCommand(release.Cmd)
 }


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/5995

This PR set the structure for the new `architect circleci trigger-job` command.