### PR TITLE
Add push and destination flag to release command

### DIFF
--- a/cmd/release/flag.go
+++ b/cmd/release/flag.go
@@ -13,4 +13,5 @@ func init() {
 	Cmd.Flags().String("docker-username", defaultDockerUsername, "username to use to login to docker registry")
 	Cmd.Flags().String("docker-password", defaultDockerPassword, "password to use to login to docker registry")
 	Cmd.Flags().BoolVar(&push, "push", true, "publish helm chart as a github release")
+	Cmd.Flags().String("destination", "architect-release", "destination folder")
 }

--- a/cmd/release/flag.go
+++ b/cmd/release/flag.go
@@ -2,10 +2,15 @@ package release
 
 import "os"
 
+var (
+	push bool
+)
+
 func init() {
 	defaultDockerUsername := os.Getenv("QUAY_USERNAME")
 	defaultDockerPassword := os.Getenv("QUAY_PASSWORD")
 
 	Cmd.Flags().String("docker-username", defaultDockerUsername, "username to use to login to docker registry")
 	Cmd.Flags().String("docker-password", defaultDockerPassword, "password to use to login to docker registry")
+	Cmd.Flags().BoolVar(&push, "push", true, "publish helm chart as a github release")
 }

--- a/cmd/release/runner.go
+++ b/cmd/release/runner.go
@@ -2,9 +2,9 @@ package release
 
 import (
 	"context"
-	"io/ioutil"
 	"log"
 	"os"
+	"path/filepath"
 
 	"github.com/google/go-github/github"
 	"github.com/spf13/afero"
@@ -49,11 +49,12 @@ func runReleaseError(cmd *cobra.Command, args []string) error {
 
 	var releaseDir string
 	{
-		releaseDir, err := ioutil.TempDir(os.TempDir(), "architect-release")
+		path := filepath.Join(cmd.Flag("working-directory").Value.String(), "architect-release")
+		err := os.Mkdir(path, os.ModePerm)
 		if err != nil {
 			return microerror.Mask(err)
 		}
-		defer os.RemoveAll(releaseDir)
+		releaseDir = path
 	}
 
 	{

--- a/cmd/release/runner.go
+++ b/cmd/release/runner.go
@@ -59,7 +59,7 @@ func runReleaseError(cmd *cobra.Command, args []string) error {
 	{
 		fs := afero.NewOsFs()
 
-		workflow, err := workflow.NewRelease(projectInfo, fs, releaseDir, githubClient)
+		workflow, err := workflow.NewRelease(projectInfo, fs, releaseDir, githubClient, push)
 		if err != nil {
 			return microerror.Mask(err)
 		}

--- a/cmd/release/runner.go
+++ b/cmd/release/runner.go
@@ -49,7 +49,7 @@ func runReleaseError(cmd *cobra.Command, args []string) error {
 
 	var releaseDir string
 	{
-		path := filepath.Join(cmd.Flag("working-directory").Value.String(), "architect-release")
+		path := filepath.Join(cmd.Flag("working-directory").Value.String(), cmd.Flag("destination").Value.String())
 		err := os.Mkdir(path, os.ModePerm)
 		if err != nil {
 			return microerror.Mask(err)

--- a/cmd/release/runner.go
+++ b/cmd/release/runner.go
@@ -50,9 +50,18 @@ func runReleaseError(cmd *cobra.Command, args []string) error {
 	var releaseDir string
 	{
 		path := filepath.Join(cmd.Flag("working-directory").Value.String(), cmd.Flag("destination").Value.String())
-		err := os.Mkdir(path, os.ModePerm)
+		_, err := os.Stat(path)
 		if err != nil {
-			return microerror.Mask(err)
+			if os.IsNotExist(err) {
+				err := os.Mkdir(path, os.ModePerm)
+				if err != nil {
+					return microerror.Mask(err)
+				}
+			} else {
+				if !os.IsExist(err) {
+					return microerror.Mask(err)
+				}
+			}
 		}
 		releaseDir = path
 	}

--- a/pack/pack.go
+++ b/pack/pack.go
@@ -2,6 +2,7 @@ package pack
 
 import (
 	"fmt"
+	"log"
 	"path/filepath"
 
 	"k8s.io/helm/pkg/chartutil"
@@ -37,10 +38,12 @@ func (p PackageHelmChartTask) Run() error {
 	}
 
 	// Save the chart as an archive in the given directory.
-	_, err = chartutil.Save(ch, p.dst)
+	savedFile, err := chartutil.Save(ch, p.dst)
 	if err != nil {
 		return microerror.Mask(err)
 	}
+
+	log.Printf("chart %s packaged at %s", ch.Metadata.GetName(), savedFile)
 
 	return nil
 }

--- a/workflow/workflow.go
+++ b/workflow/workflow.go
@@ -2,7 +2,6 @@ package workflow
 
 import (
 	"fmt"
-	"io/ioutil"
 	"path/filepath"
 	"strings"
 
@@ -282,11 +281,6 @@ func NewPublish(projectInfo ProjectInfo, fs afero.Fs) (Workflow, error) {
 
 func NewRelease(projectInfo ProjectInfo, fs afero.Fs, releaseDir string, githubClient *github.Client, push bool) (Workflow, error) {
 	w := Workflow{}
-
-	releaseDir, err := ioutil.TempDir("", "release")
-	if err != nil {
-		return nil, microerror.Mask(err)
-	}
 
 	packageTaskCreator := NewPackageHelmChartTaskCreator(releaseDir)
 	helmTasks, err := processHelmDir(fs, projectInfo, packageTaskCreator)


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/6025

With the new push-to-catalog approach, we need architect to be able to package helm chart locally but prevent it to publish them as github releases (in case of test versions).

This PR introduces 2 new flags:
- `--push`: when set to false this prevent the helm chart to be published as github release.
- `--destination`: destination folder where to put the helm chart archives.
It also fixes the logic for `destination/releaseDir` directory which was quite broken.