### PR TITLE
split git related arguments into PreRun hook

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -5,20 +5,22 @@ import (
 	"os"
 	"path"
 
-	"github.com/giantswarm/architect/tasks"
-	"github.com/giantswarm/architect/workflow"
 	"github.com/jstemmer/go-junit-report/formatter"
 	"github.com/jstemmer/go-junit-report/parser"
-
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
+
+	"github.com/giantswarm/architect/cmd/hook"
+	"github.com/giantswarm/architect/tasks"
+	"github.com/giantswarm/architect/workflow"
 )
 
 var (
 	buildCmd = &cobra.Command{
-		Use:   "build",
-		Short: "build the project",
-		Run:   runBuild,
+		Use:     "build",
+		Short:   "build the project",
+		Run:     runBuild,
+		PreRunE: hook.PreRunE,
 	}
 
 	dockerUsername string
@@ -63,11 +65,11 @@ func runBuild(cmd *cobra.Command, args []string) {
 		Organisation:     organisation,
 		Project:          project,
 
-		Branch: branch,
-		Sha:    sha,
-		Tag:    tag,
+		Branch: cmd.Flag("branch").Value.String(),
+		Sha:    cmd.Flag("sha").Value.String(),
+		Tag:    cmd.Flag("tag").Value.String(),
 
-		Version: version,
+		Version: cmd.Flag("version").Value.String(),
 
 		Registry:       registry,
 		DockerUsername: dockerUsername,

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -10,6 +10,7 @@ import (
 	"github.com/spf13/cobra"
 	"golang.org/x/oauth2"
 
+	"github.com/giantswarm/architect/cmd/hook"
 	"github.com/giantswarm/architect/events"
 	"github.com/giantswarm/architect/tasks"
 	"github.com/giantswarm/architect/workflow"
@@ -17,9 +18,10 @@ import (
 
 var (
 	deployCmd = &cobra.Command{
-		Use:   "deploy",
-		Short: "deploy the project",
-		Run:   runDeploy,
+		Use:     "deploy",
+		Short:   "deploy the project",
+		Run:     runDeploy,
+		PreRunE: hook.PreRunE,
 	}
 
 	deploymentEventsToken string
@@ -54,11 +56,11 @@ func runDeploy(cmd *cobra.Command, args []string) {
 		Organisation:     organisation,
 		Project:          project,
 
-		Branch: branch,
-		Sha:    sha,
-		Tag:    tag,
+		Branch: cmd.Flag("branch").Value.String(),
+		Sha:    cmd.Flag("sha").Value.String(),
+		Tag:    cmd.Flag("tag").Value.String(),
 
-		Version: version,
+		Version: cmd.Flag("version").Value.String(),
 
 		Registry:       registry,
 		DockerUsername: dockerUsername,

--- a/cmd/helm/template/command.go
+++ b/cmd/helm/template/command.go
@@ -2,12 +2,15 @@ package template
 
 import (
 	"github.com/spf13/cobra"
+
+	"github.com/giantswarm/architect/cmd/hook"
 )
 
 var (
 	Cmd = &cobra.Command{
-		Use:   "template",
-		Short: "templates helm chart",
-		RunE:  runTemplateError,
+		Use:     "template",
+		Short:   "templates helm chart",
+		RunE:    runTemplateError,
+		PreRunE: hook.PreRunE,
 	}
 )

--- a/cmd/hook/error.go
+++ b/cmd/hook/error.go
@@ -1,0 +1,21 @@
+package hook
+
+import (
+	"github.com/giantswarm/microerror"
+)
+
+var gitNoSHAError = &microerror.Error{
+	Kind: "gitNoSHAError",
+}
+
+func IsGitNoSHAError(err error) bool {
+	return microerror.Cause(err) == gitNoSHAError
+}
+
+var gitNoBranchError = &microerror.Error{
+	Kind: "gitNoBranchError",
+}
+
+func IsGitNoBranchError(err error) bool {
+	return microerror.Cause(err) == gitNoBranchError
+}

--- a/cmd/hook/preRunE.go
+++ b/cmd/hook/preRunE.go
@@ -1,0 +1,72 @@
+package hook
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"os/exec"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+func PreRunE(cmd *cobra.Command, args []string) error {
+	// Use git HEAD as defaultSha.
+	var defaultSha string
+	{
+		out, err := exec.Command("git", "rev-parse", "HEAD").Output()
+		if err != nil {
+			log.Fatalf("could not get git sha: %#v\n", err)
+		}
+		defaultSha = strings.TrimSpace(string(out))
+	}
+
+	// Use git tag when available.
+	var defaultTag string
+	{
+		out, err := exec.Command("git", "describe", "--tags", "--exact-match", "HEAD").Output()
+		if err == nil {
+			// Always populate tag unless building on CircleCI and it is not explicitly requesting to build a tag.
+			if _, ciTagExists := os.LookupEnv("CIRCLE_TAG"); os.Getenv("CIRCLECI") != "true" || ciTagExists {
+				defaultTag = strings.TrimPrefix(strings.TrimSpace(string(out)), "v")
+			}
+		}
+	}
+
+	// We also use the git HEAD branch as well.
+	var defaultBranch string
+	{
+		out, err := exec.Command("git", "rev-parse", "--abbrev-ref", "HEAD").Output()
+		if err != nil {
+			log.Fatalf("could not get git branch: %#v\n", err)
+		}
+		defaultBranch = strings.TrimSpace(string(out))
+	}
+
+	// Define the version we are building.
+	var defaultVersion string
+	{
+		// version can be of three different formats:
+		//   2.0.0: building a tagged version.
+		//   2.0.0-3a955cbb126f0fe5d51aedf2eb84acca7b074374: building ahead of a tagged version.
+		//   1.0.0-939f5c6949f83c0a7ea98a25bc9524fd2f751ffe: building a repo which has no tags.
+		if defaultTag != "" {
+			defaultVersion = defaultTag
+		} else {
+			out, err := exec.Command("git", "describe", "--tags", "--abbrev=0", "HEAD").Output()
+			if err != nil {
+				defaultVersion = fmt.Sprintf("1.0.0-%s", defaultSha)
+			} else {
+				defaultVersion = fmt.Sprintf("%s-%s", strings.TrimPrefix(strings.TrimSpace(string(out)), "v"), defaultSha)
+			}
+
+		}
+	}
+
+	cmd.PersistentFlags().String("branch", defaultBranch, "git branch being built")
+	cmd.PersistentFlags().String("sha", defaultSha, "git SHA1 being built")
+	cmd.PersistentFlags().String("tag", defaultTag, "git tag being built")
+	cmd.PersistentFlags().String("version", defaultVersion, "project version being built")
+
+	return nil
+}

--- a/cmd/hook/preRunE.go
+++ b/cmd/hook/preRunE.go
@@ -2,11 +2,11 @@ package hook
 
 import (
 	"fmt"
-	"log"
 	"os"
 	"os/exec"
 	"strings"
 
+	"github.com/giantswarm/microerror"
 	"github.com/spf13/cobra"
 )
 
@@ -16,7 +16,7 @@ func PreRunE(cmd *cobra.Command, args []string) error {
 	{
 		out, err := exec.Command("git", "rev-parse", "HEAD").Output()
 		if err != nil {
-			log.Fatalf("could not get git sha: %#v\n", err)
+			return microerror.Maskf(gitNoSHAError, "could not get git sha: %#v\n", err)
 		}
 		defaultSha = strings.TrimSpace(string(out))
 	}
@@ -38,7 +38,7 @@ func PreRunE(cmd *cobra.Command, args []string) error {
 	{
 		out, err := exec.Command("git", "rev-parse", "--abbrev-ref", "HEAD").Output()
 		if err != nil {
-			log.Fatalf("could not get git branch: %#v\n", err)
+			return microerror.Maskf(gitNoBranchError, "could not get git branch: %#v\n", err)
 		}
 		defaultBranch = strings.TrimSpace(string(out))
 	}

--- a/cmd/publish.go
+++ b/cmd/publish.go
@@ -8,6 +8,7 @@ import (
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 
+	"github.com/giantswarm/architect/cmd/hook"
 	"github.com/giantswarm/architect/pipeline"
 	"github.com/giantswarm/architect/tasks"
 	"github.com/giantswarm/architect/workflow"
@@ -15,9 +16,10 @@ import (
 
 var (
 	publishCmd = &cobra.Command{
-		Use:   "publish",
-		Short: "publish charts to the specified channels",
-		Run:   runPublish,
+		Use:     "publish",
+		Short:   "publish charts to the specified channels",
+		Run:     runPublish,
+		PreRunE: hook.PreRunE,
 	}
 
 	channels      string
@@ -69,11 +71,11 @@ func runPublish(cmd *cobra.Command, args []string) {
 		Organisation:     organisation,
 		Project:          project,
 
-		Branch: branch,
-		Sha:    sha,
-		Tag:    tag,
+		Branch: cmd.Flag("branch").Value.String(),
+		Sha:    cmd.Flag("sha").Value.String(),
+		Tag:    cmd.Flag("tag").Value.String(),
 
-		Version: version,
+		Version: cmd.Flag("version").Value.String(),
 
 		Registry:       registry,
 		DockerUsername: dockerUsername,

--- a/cmd/release/command.go
+++ b/cmd/release/command.go
@@ -2,12 +2,15 @@ package release
 
 import (
 	"github.com/spf13/cobra"
+
+	"github.com/giantswarm/architect/cmd/hook"
 )
 
 var (
 	Cmd = &cobra.Command{
-		Use:   "release",
-		Short: "release chart as github release",
-		RunE:  runReleaseError,
+		Use:     "release",
+		Short:   "release chart as github release",
+		RunE:    runReleaseError,
+		PreRunE: hook.PreRunE,
 	}
 )

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,10 +1,8 @@
 package cmd
 
 import (
-	"fmt"
 	"log"
 	"os"
-	"os/exec"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -54,58 +52,6 @@ func init() {
 		defaultProject = path[len(path)-1]
 	}
 
-	// Use git HEAD as defaultSha.
-	var defaultSha string
-	{
-		out, err := exec.Command("git", "rev-parse", "HEAD").Output()
-		if err != nil {
-			log.Fatalf("could not get git sha: %#v\n", err)
-		}
-		defaultSha = strings.TrimSpace(string(out))
-	}
-
-	// Use git tag when available.
-	var defaultTag string
-	{
-		out, err := exec.Command("git", "describe", "--tags", "--exact-match", "HEAD").Output()
-		if err == nil {
-			// Always populate tag unless building on CircleCI and it is not explicitly requesting to build a tag.
-			if _, ciTagExists := os.LookupEnv("CIRCLE_TAG"); os.Getenv("CIRCLECI") != "true" || ciTagExists {
-				defaultTag = strings.TrimPrefix(strings.TrimSpace(string(out)), "v")
-			}
-		}
-	}
-
-	// We also use the git HEAD branch as well.
-	var defaultBranch string
-	{
-		out, err := exec.Command("git", "rev-parse", "--abbrev-ref", "HEAD").Output()
-		if err != nil {
-			log.Fatalf("could not get git branch: %#v\n", err)
-		}
-		defaultBranch = strings.TrimSpace(string(out))
-	}
-
-	// Define the version we are building.
-	var defaultVersion string
-	{
-		// version can be of three different formats:
-		//   2.0.0: building a tagged version.
-		//   2.0.0-3a955cbb126f0fe5d51aedf2eb84acca7b074374: building ahead of a tagged version.
-		//   1.0.0-939f5c6949f83c0a7ea98a25bc9524fd2f751ffe: building a repo which has no tags.
-		if defaultTag != "" {
-			defaultVersion = defaultTag
-		} else {
-			out, err := exec.Command("git", "describe", "--tags", "--abbrev=0", "HEAD").Output()
-			if err != nil {
-				defaultVersion = fmt.Sprintf("1.0.0-%s", defaultSha)
-			} else {
-				defaultVersion = fmt.Sprintf("%s-%s", strings.TrimPrefix(strings.TrimSpace(string(out)), "v"), defaultSha)
-			}
-
-		}
-	}
-
 	var githubToken string
 	{
 		githubToken = os.Getenv("DEPLOYMENT_EVENTS_TOKEN")
@@ -117,12 +63,6 @@ func init() {
 	RootCmd.PersistentFlags().StringVar(&registry, "registry", "quay.io", "docker registry")
 	RootCmd.PersistentFlags().StringVar(&organisation, "organisation", defaultOrganisation, "organisation who owns the project")
 	RootCmd.PersistentFlags().StringVar(&project, "project", defaultProject, "name of the project")
-
-	RootCmd.PersistentFlags().StringVar(&branch, "branch", defaultBranch, "git branch being built")
-	RootCmd.PersistentFlags().StringVar(&sha, "sha", defaultSha, "git SHA1 being built")
-	RootCmd.PersistentFlags().StringVar(&tag, "tag", defaultTag, "git tag being built")
-
-	RootCmd.PersistentFlags().StringVar(&version, "version", defaultVersion, "project version being built")
 
 	RootCmd.PersistentFlags().BoolVar(&dryRun, "dry-run", dryRun, "show what would be executed, but take no action")
 

--- a/cmd/unpublish.go
+++ b/cmd/unpublish.go
@@ -8,15 +8,17 @@ import (
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 
+	"github.com/giantswarm/architect/cmd/hook"
 	"github.com/giantswarm/architect/tasks"
 	"github.com/giantswarm/architect/workflow"
 )
 
 var (
 	unpublishCmd = &cobra.Command{
-		Use:   "unpublish",
-		Short: "unpublish charts from the specified channels",
-		Run:   runUnpublish,
+		Use:     "unpublish",
+		Short:   "unpublish charts from the specified channels",
+		Run:     runUnpublish,
+		PreRunE: hook.PreRunE,
 	}
 )
 
@@ -47,11 +49,11 @@ func runUnpublish(cmd *cobra.Command, args []string) {
 		Organisation:     organisation,
 		Project:          project,
 
-		Branch: branch,
-		Sha:    sha,
-		Tag:    tag,
+		Branch: cmd.Flag("branch").Value.String(),
+		Sha:    cmd.Flag("sha").Value.String(),
+		Tag:    cmd.Flag("tag").Value.String(),
 
-		Version: version,
+		Version: cmd.Flag("version").Value.String(),
 
 		Registry:       registry,
 		DockerUsername: dockerUsername,


### PR DESCRIPTION
Towards: giantswarm/giantswarm#6025

This PR fixes a bug, where `architect version` and `architect --help` cannot be run outside a git repository and yiel errors (see https://circleci.com/gh/giantswarm/architect/870):
```
2019/05/31 12:40:16 could not get git sha: &exec.ExitError{ProcessState:(*os.ProcessState)(0xc00000ad40), Stderr:[]uint8{0x66, 0x61, 0x74, 0x61, 0x6c, 0x3a, 0x20, 0x6e, 0x6f, 0x74, 0x20, 0x61, 0x20, 0x67, 0x69, 0x74, 0x20, 0x72, 0x65, 0x70, 0x6f, 0x73, 0x69, 0x74, 0x6f, 0x72, 0x79, 0x20, 0x28, 0x6f, 0x72, 0x20, 0x61, 0x6e, 0x79, 0x20, 0x6f, 0x66, 0x20, 0x74, 0x68, 0x65, 0x20, 0x70, 0x61, 0x72, 0x65, 0x6e, 0x74, 0x20, 0x64, 0x69, 0x72, 0x65, 0x63, 0x74, 0x6f, 0x72, 0x69, 0x65, 0x73, 0x29, 0x3a, 0x20, 0x2e, 0x67, 0x69, 0x74, 0xa}}
```
This is actually required in order to be able to package architect into a container see https://github.com/giantswarm/architect/pull/310