### PR TITLE
tag and push docker latest image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,5 +16,6 @@ jobs:
     - deploy:
         command: |
           if [ "${CIRCLE_BRANCH}" == "master" ]; then
+            ./architect deploy
             ./github-release.sh $CIRCLE_SHA1 $PERSONAL_ACCESS_TOKEN
           fi


### PR DESCRIPTION
Towards: giantswarm/giantswarm#6025

This PR call `architect deploy` when building the master branch, this is needed in order to have `quay.io/giantswarm/architect:latest` docker image available.