### PR TITLE
removed unused variables

### DIFF
--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -102,7 +102,7 @@ func runDeploy(cmd *cobra.Command, args []string) {
 
 	log.Printf("creating for environments: %v", environments)
 	for _, environment := range environments {
-		if err := events.CreateDeploymentEvent(githubClient, environment, organisation, project, sha); err != nil {
+		if err := events.CreateDeploymentEvent(githubClient, environment, organisation, project, cmd.Flag("sha").Value.String()); err != nil {
 			log.Fatalf("could not create deployment event: %v", err)
 		}
 	}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -23,12 +23,6 @@ var (
 	organisation string
 	project      string
 
-	branch string
-	sha    string
-	tag    string
-
-	version string
-
 	dryRun bool
 )
 


### PR DESCRIPTION
Fix an issue where build fail due to empty `sha` variable.
https://circleci.com/gh/giantswarm/giantswarmio-webapp/648

This was introduced in a previous change https://github.com/giantswarm/architect/pull/311

The logic to get sha, tag, branch and version was moved to a different package. We therefore cannot set those values in the `cmd` package.

The way to go now is to use the `cmd.Flag("sha").Value.String()` to retrieve flag values.
