### PR TITLE
inject pkg/project.buildTimestamp on golang build

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -4,6 +4,7 @@ import (
 	"log"
 	"os"
 	"path"
+	"time"
 
 	"github.com/jstemmer/go-junit-report/formatter"
 	"github.com/jstemmer/go-junit-report/parser"
@@ -64,6 +65,8 @@ func runBuild(cmd *cobra.Command, args []string) {
 		WorkingDirectory: workingDirectory,
 		Organisation:     organisation,
 		Project:          project,
+
+		BuildTimestamp: time.Now(),
 
 		Branch: cmd.Flag("branch").Value.String(),
 		Sha:    cmd.Flag("sha").Value.String(),

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -5,6 +5,8 @@ import (
 	"os"
 
 	"github.com/spf13/cobra"
+
+	pkgproject "github.com/giantswarm/architect/pkg/project"
 )
 
 var (
@@ -13,9 +15,6 @@ var (
 		Short: "show version information",
 		Run:   runVersion,
 	}
-
-	Commit         string
-	BuildTimestamp string
 )
 
 func init() {
@@ -23,11 +22,11 @@ func init() {
 }
 
 func runVersion(cmd *cobra.Command, args []string) {
-	if Commit == "" && BuildTimestamp == "" {
+	if pkgproject.GitSHA() == "" && pkgproject.BuildTimestamp() == "" {
 		fmt.Printf("version information not compiled\n")
 		os.Exit(0)
 	}
 
-	fmt.Printf("Git Commit Hash: %s\n", Commit)
-	fmt.Printf("Build Timestamp: %s\n", BuildTimestamp)
+	fmt.Printf("Git Commit Hash: %s\n", pkgproject.GitSHA())
+	fmt.Printf("Build Timestamp: %s\n", pkgproject.BuildTimestamp())
 }

--- a/pkg/project/project.go
+++ b/pkg/project/project.go
@@ -1,0 +1,14 @@
+package project
+
+var (
+	buildTimestamp string
+	gitSHA         string
+)
+
+func BuildTimestamp() string {
+	return buildTimestamp
+}
+
+func GitSHA() string {
+	return gitSHA
+}

--- a/workflow/docker_test.go
+++ b/workflow/docker_test.go
@@ -3,6 +3,7 @@ package workflow
 import (
 	"reflect"
 	"testing"
+	"time"
 
 	"github.com/giantswarm/architect/tasks"
 )
@@ -178,6 +179,8 @@ func testNewProjectInfo() ProjectInfo {
 		WorkingDirectory: "/usr/code/",
 		Organisation:     "giantswarm",
 		Project:          "architect",
+
+		BuildTimestamp: time.Date(2019, time.June, 04, 12, 40, 05, 0, time.UTC),
 
 		Branch: "master",
 		Sha:    "e8363ac222255e991c126abe6673cd0f33934ac8",

--- a/workflow/golang.go
+++ b/workflow/golang.go
@@ -7,6 +7,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/giantswarm/architect/tasks"
 	"github.com/giantswarm/microerror"
@@ -262,6 +263,7 @@ func NewGoBuildTask(fs afero.Fs, projectInfo ProjectInfo) (tasks.Task, error) {
 					"-linkmode 'auto'",
 					"-extldflags '-static'",
 					fmt.Sprintf("-X 'main.gitCommit=%s'", projectInfo.Sha),
+					fmt.Sprintf("-X 'github.com/%s/%s/pkg/project.buildTimestamp=%s'", projectInfo.Organisation, projectInfo.Project, projectInfo.BuildTimestamp.UTC().Format(time.RFC3339)),
 					fmt.Sprintf("-X 'github.com/%s/%s/pkg/project.gitSHA=%s'", projectInfo.Organisation, projectInfo.Project, projectInfo.Sha),
 					fmt.Sprintf("-X 'github.com/%s/%s/pkg/project.version=%s'", projectInfo.Organisation, projectInfo.Project, projectInfo.Version),
 				}, " "),

--- a/workflow/golang_test.go
+++ b/workflow/golang_test.go
@@ -54,6 +54,7 @@ func TestNewGoBuildTask(t *testing.T) {
 					"-linkmode 'auto' " +
 					"-extldflags '-static' " +
 					"-X 'main.gitCommit=e8363ac222255e991c126abe6673cd0f33934ac8' " +
+					"-X 'github.com/giantswarm/architect/pkg/project.buildTimestamp=2019-06-04T12:40:05Z' " +
 					"-X 'github.com/giantswarm/architect/pkg/project.gitSHA=e8363ac222255e991c126abe6673cd0f33934ac8' " +
 					"-X 'github.com/giantswarm/architect/pkg/project.version=test'",
 			},

--- a/workflow/workflow.go
+++ b/workflow/workflow.go
@@ -5,6 +5,7 @@ import (
 	"io/ioutil"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/cenk/backoff"
 	"github.com/giantswarm/architect/tasks"
@@ -33,6 +34,8 @@ type ProjectInfo struct {
 	WorkingDirectory string
 	Organisation     string
 	Project          string
+
+	BuildTimestamp time.Time
 
 	Branch string
 	Sha    string


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/6025

This PR fixes an issue where `architect version` yield `version information not compiled`.

```
$ docker run --rm --name architect quay.io/giantswarm/architect version
version information not compiled
```

So now on every golang project being build we inject the build timestamp in `pkg/project.buildTimestamp`.