### PR TITLE
workflow: don't fail for helm subdirectories w/o -chart suffix

### DIFF
--- a/workflow/workflow.go
+++ b/workflow/workflow.go
@@ -371,7 +371,7 @@ func processHelmDir(fs afero.Fs, projectInfo ProjectInfo, f func(afero.Fs, strin
 			w = append(w, helmLogin)
 		}
 
-		prefix := projectInfo.Project + "-"
+		prefix := projectInfo.Project
 		suffix := "-chart"
 		for _, fileInfo := range fileInfos {
 			if !fileInfo.IsDir() {
@@ -381,7 +381,7 @@ func processHelmDir(fs afero.Fs, projectInfo ProjectInfo, f func(afero.Fs, strin
 				return nil, microerror.Maskf(invalidHelmDirectoryError, "%q must start with %q", fileInfo.Name(), prefix)
 			}
 			if !strings.HasSuffix(fileInfo.Name(), suffix) {
-				return nil, microerror.Maskf(invalidHelmDirectoryError, "%q must end with %q", fileInfo.Name(), suffix)
+				continue
 			}
 
 			chartDir := filepath.Join(helmDirectory, fileInfo.Name())


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/6154.

They are skipped now instead.