### PR TITLE
Skip templating tgz files

### DIFF
--- a/template/helm.go
+++ b/template/helm.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"os"
+	"strings"
 	"text/template"
 
 	"github.com/spf13/afero"
@@ -40,6 +41,10 @@ type TemplateHelmChartTask struct {
 // Run templates the chart's Chart.yaml and templates/deployment.yaml.
 func (t TemplateHelmChartTask) Run() error {
 	err := afero.Walk(t.fs, t.chartDir, func(path string, info os.FileInfo, err error) error {
+		if strings.HasSuffix(info.Name(), ".tgz") {
+			return nil
+		}
+
 		contents, err := afero.ReadFile(t.fs, path)
 		if err != nil {
 			microerror.Mask(err)

--- a/template/helm_test.go
+++ b/template/helm_test.go
@@ -65,7 +65,7 @@ func TestTemplateHelmChartTask(t *testing.T) {
 					},
 					{
 						path: filepath.Join(chartDir, "charts", "foo.tgz"),
-						data: "version: [[ .SHA ]]",
+						data: "version: [[ .SHA ]] - not templated as .tgz files are ignored",
 					},
 				}
 

--- a/template/helm_test.go
+++ b/template/helm_test.go
@@ -122,7 +122,7 @@ func TestTemplateHelmChartTask(t *testing.T) {
 					},
 					{
 						path: filepath.Join(chartDir, "charts", "foo.tgz"),
-						data: "version: [[ .SHA ]]",
+						data: "version: [[ .SHA ]] - not templated as .tgz files are ignored",
 					},
 				}
 

--- a/template/helm_test.go
+++ b/template/helm_test.go
@@ -63,6 +63,10 @@ func TestTemplateHelmChartTask(t *testing.T) {
 						path: filepath.Join(chartDir, HelmTemplateDirectoryName, "with-version.yaml"),
 						data: "version: [[ .Version ]]",
 					},
+					{
+						path: filepath.Join(chartDir, "charts", "foo.tgz"),
+						data: "version: [[ .SHA ]]",
+					},
 				}
 
 				for _, file := range files {
@@ -115,6 +119,10 @@ func TestTemplateHelmChartTask(t *testing.T) {
 					{
 						path: filepath.Join(chartDir, HelmTemplateDirectoryName, "with-version.yaml"),
 						data: "version: mad-hatter",
+					},
+					{
+						path: filepath.Join(chartDir, "charts", "foo.tgz"),
+						data: "version: [[ .SHA ]]",
 					},
 				}
 


### PR DESCRIPTION
While configuring CircleCI configuration for packaging and pushing EFK chart to incubator app catalog (see https://github.com/giantswarm/kubernetes-elastic-stack/pull/53) it was discovered that current `architect helm template` command logic assumes all Helm chart files are text files and are treated as template source. EFK chart as it currently stands is a bill-of-materials chart packaging multiple other chart dependencies, provided as tarball packages. Running `architect helm template` for EFK chart panics when trying to template these archives (see https://circleci.com/gh/giantswarm/kubernetes-elastic-stack/4).

This PR supports skipping templating of *.tgz files.