### PR TITLE
Revert "Remove ginger from the testing group. (#297)"

### DIFF
--- a/events/events.go
+++ b/events/events.go
@@ -116,6 +116,7 @@ var testingGroup = []Environment{
 	"gauss",
 	"geckon",
 	"ghost",
+	"ginger",
 	"giraffe",
 	"godsmack",
 	"gorgoth",


### PR DESCRIPTION
This reverts commit ee946e6eb575652e4e5d7d58be547baaf5ab5436.

Because ginger is a testing environment again for a while now.