### PR TITLE
Fix error handling in helm templating walk

### DIFF
--- a/template/helm.go
+++ b/template/helm.go
@@ -41,13 +41,17 @@ type TemplateHelmChartTask struct {
 // Run templates the chart's Chart.yaml and templates/deployment.yaml.
 func (t TemplateHelmChartTask) Run() error {
 	err := afero.Walk(t.fs, t.chartDir, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return microerror.Mask(err)
+		}
+
 		if strings.HasSuffix(info.Name(), ".tgz") {
 			return nil
 		}
 
 		contents, err := afero.ReadFile(t.fs, path)
 		if err != nil {
-			microerror.Mask(err)
+			return microerror.Mask(err)
 		}
 
 		buildInfo := BuildInfo{
@@ -58,16 +62,16 @@ func (t TemplateHelmChartTask) Run() error {
 
 		newTemplate := template.Must(template.New(path).Delims("[[", "]]").Parse(string(contents)))
 		if err != nil {
-			microerror.Mask(err)
+			return microerror.Mask(err)
 		}
 
 		var buf bytes.Buffer
 		if err := newTemplate.Execute(&buf, buildInfo); err != nil {
-			microerror.Mask(err)
+			return microerror.Mask(err)
 		}
 
 		if err := afero.WriteFile(t.fs, path, buf.Bytes(), permission); err != nil {
-			microerror.Mask(err)
+			return microerror.Mask(err)
 		}
 		return nil
 	})


### PR DESCRIPTION
This PR fixes error handling in helm templating walk. It also handles case when walk is called with non-nil error passed in.

Bug was uncovered by @pipo02mix when trying to `architect helm template` https://github.com/giantswarm/prometheus-operator-app/tree/master/helm/kubernetes-prometheus-chart 
See related discussion on slack: https://gigantic.slack.com/archives/C3C7ZQXC1/p1562842254031900