### PR TITLE
Make helm template tgz check nil safe

### DIFF
--- a/template/helm.go
+++ b/template/helm.go
@@ -41,7 +41,7 @@ type TemplateHelmChartTask struct {
 // Run templates the chart's Chart.yaml and templates/deployment.yaml.
 func (t TemplateHelmChartTask) Run() error {
 	err := afero.Walk(t.fs, t.chartDir, func(path string, info os.FileInfo, err error) error {
-		if strings.HasSuffix(info.Name(), ".tgz") {
+		if info != nil && strings.HasSuffix(info.Name(), ".tgz") {
 			return nil
 		}
 


### PR DESCRIPTION
This PR makes `architect helm template` tgz check nil safe.

I've tested it on https://github.com/giantswarm/prometheus-operator-app/tree/master/helm/kubernetes-prometheus-chart - before PR `architect helm template` would segfault, and after it completes successfully.

```
$ architect helm template --dir ./helm/prometheus-operator-app-chart
2019/07/12 00:03:17 templating helm chart
dir: ./helm/prometheus-operator-app-chart
sha: e877bd37b17d9b7e75d762ec61ac2a3d73220962
tag: 0.1.0
version: 0.1.0
2019/07/12 00:03:17 templated helm chart
```