### PR TITLE
new command: architect project version

### DIFF
--- a/cmd/project/command.go
+++ b/cmd/project/command.go
@@ -1,0 +1,17 @@
+package project
+
+import (
+	"github.com/giantswarm/architect/cmd/project/version"
+	"github.com/spf13/cobra"
+)
+
+var (
+	Cmd = &cobra.Command{
+		Use:   "project",
+		Short: "show project informations",
+	}
+)
+
+func init() {
+	Cmd.AddCommand(version.Cmd)
+}

--- a/cmd/project/version/command.go
+++ b/cmd/project/version/command.go
@@ -1,0 +1,16 @@
+package version
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/giantswarm/architect/cmd/hook"
+)
+
+var (
+	Cmd = &cobra.Command{
+		Use:     "version",
+		Short:   "show project version",
+		RunE:    runVersionError,
+		PreRunE: hook.PreRunE,
+	}
+)

--- a/cmd/project/version/runner.go
+++ b/cmd/project/version/runner.go
@@ -1,0 +1,15 @@
+package version
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+func runVersionError(cmd *cobra.Command, args []string) error {
+	version := cmd.Flag("version").Value.String()
+
+	fmt.Printf("%s\n", version)
+
+	return nil
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -8,6 +8,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/giantswarm/architect/cmd/helm"
+	cmdProject "github.com/giantswarm/architect/cmd/project"
 	"github.com/giantswarm/architect/cmd/release"
 )
 
@@ -62,4 +63,5 @@ func init() {
 
 	RootCmd.AddCommand(release.Cmd)
 	RootCmd.AddCommand(helm.Cmd)
+	RootCmd.AddCommand(cmdProject.Cmd)
 }


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/6557

This PR provides a new command: `architect project version` which just output the version being discovered by architect when building a project. So we can re-use this from other scripts like circleci orbs.