### PR TITLE
remove support for .DockerTag in helm template

### DIFF
--- a/template/helm.go
+++ b/template/helm.go
@@ -31,7 +31,8 @@ const (
 )
 
 type TemplateHelmChartTask struct {
-	fs       afero.Fs
+	fs afero.Fs
+
 	chartDir string
 	sha      string
 	version  string

--- a/template/helm.go
+++ b/template/helm.go
@@ -17,8 +17,8 @@ const (
 
 	// TemplateHelmChartTaskString is the format for printing the
 	// helm chart templating task.
-	// Name of the task, the helm directory path, the docker-tag, the sha, and the version.
-	TemplateHelmChartTaskString = "%s:\t%s docker-tag:%s sha:%s version:%s"
+	// Name of the task, the helm directory path, the sha, and the version.
+	TemplateHelmChartTaskString = "%s:\t%s sha:%s version:%s"
 
 	// HelmChartYamlName is the name of Helm's chart yaml.
 	HelmChartYamlName = "Chart.yaml"
@@ -31,11 +31,10 @@ const (
 )
 
 type TemplateHelmChartTask struct {
-	dockerTag string
-	fs        afero.Fs
-	chartDir  string
-	sha       string
-	version   string
+	fs       afero.Fs
+	chartDir string
+	sha      string
+	version  string
 }
 
 // Run templates the chart's Chart.yaml and templates/deployment.yaml.
@@ -51,9 +50,8 @@ func (t TemplateHelmChartTask) Run() error {
 		}
 
 		buildInfo := BuildInfo{
-			DockerTag: t.dockerTag,
-			SHA:       t.sha,
-			Version:   t.version,
+			SHA:     t.sha,
+			Version: t.version,
 		}
 
 		newTemplate := template.Must(template.New(path).Delims("[[", "]]").Parse(string(contents)))
@@ -84,15 +82,14 @@ func (t TemplateHelmChartTask) Name() string {
 }
 
 func (t TemplateHelmChartTask) String() string {
-	return fmt.Sprintf(TemplateHelmChartTaskString, t.Name(), t.chartDir, t.dockerTag, t.sha, t.version)
+	return fmt.Sprintf(TemplateHelmChartTaskString, t.Name(), t.chartDir, t.sha, t.version)
 }
 
-func NewTemplateHelmChartTask(fs afero.Fs, chartDir, dockerTag, sha, version string) TemplateHelmChartTask {
+func NewTemplateHelmChartTask(fs afero.Fs, chartDir, sha, version string) TemplateHelmChartTask {
 	return TemplateHelmChartTask{
-		dockerTag: dockerTag,
-		fs:        fs,
-		chartDir:  chartDir,
-		sha:       sha,
-		version:   version,
+		fs:       fs,
+		chartDir: chartDir,
+		sha:      sha,
+		version:  version,
 	}
 }

--- a/template/helm_test.go
+++ b/template/helm_test.go
@@ -13,19 +13,17 @@ import (
 // TestTemplateHelmChartTask tests the TemplateHelmChartTask.
 func TestTemplateHelmChartTask(t *testing.T) {
 	tests := []struct {
-		chartDir  string
-		dockerTag string
-		sha       string
-		version   string
-		setUp     func(afero.Fs, string) error
-		check     func(afero.Fs, string) error
+		chartDir string
+		sha      string
+		version  string
+		setUp    func(afero.Fs, string) error
+		check    func(afero.Fs, string) error
 	}{
 		// Test that a chart is templated correctly.
 		{
-			chartDir:  "/helm/test-chart",
-			dockerTag: "white-rabbit",
-			sha:       "jabberwocky",
-			version:   "mad-hatter",
+			chartDir: "/helm/test-chart",
+			sha:      "jabberwocky",
+			version:  "mad-hatter",
 			setUp: func(fs afero.Fs, chartDir string) error {
 				files := []struct {
 					path string
@@ -54,10 +52,6 @@ func TestTemplateHelmChartTask(t *testing.T) {
 					{
 						path: filepath.Join(chartDir, HelmTemplateDirectoryName, "ingress.yaml"),
 						data: "host: {{ .Values.Installation.etc }}",
-					},
-					{
-						path: filepath.Join(chartDir, HelmTemplateDirectoryName, "with-dockerTag.yaml"),
-						data: "image: [[ .DockerTag ]]",
 					},
 					{
 						path: filepath.Join(chartDir, HelmTemplateDirectoryName, "with-version.yaml"),
@@ -113,10 +107,6 @@ func TestTemplateHelmChartTask(t *testing.T) {
 						data: "host: {{ .Values.Installation.etc }}",
 					},
 					{
-						path: filepath.Join(chartDir, HelmTemplateDirectoryName, "with-dockerTag.yaml"),
-						data: "image: white-rabbit",
-					},
-					{
 						path: filepath.Join(chartDir, HelmTemplateDirectoryName, "with-version.yaml"),
 						data: "version: mad-hatter",
 					},
@@ -143,7 +133,7 @@ func TestTemplateHelmChartTask(t *testing.T) {
 
 	for index, test := range tests {
 		fs := afero.NewMemMapFs()
-		task := NewTemplateHelmChartTask(fs, test.chartDir, test.dockerTag, test.sha, test.version)
+		task := NewTemplateHelmChartTask(fs, test.chartDir, test.sha, test.version)
 
 		if err := test.setUp(fs, test.chartDir); err != nil {
 			t.Fatalf("%v: unexpected error during setup: %v\n", index, err)

--- a/template/template.go
+++ b/template/template.go
@@ -13,8 +13,6 @@ var (
 
 // BuildInfo holds information concerning the current build.
 type BuildInfo struct {
-	// DockerTag is the docker image tag.
-	DockerTag string
 	// SHA is the SHA-1 tag of the commit we are building for.
 	SHA string
 	// Version is the version of the commit being built.

--- a/workflow/helm.go
+++ b/workflow/helm.go
@@ -44,19 +44,9 @@ func NewHelmPullTask(fs afero.Fs, projectInfo ProjectInfo) (tasks.Task, error) {
 }
 
 func NewTemplateHelmChartTask(fs afero.Fs, chartDir string, projectInfo ProjectInfo) (tasks.Task, error) {
-	var dockerTag string
-	{
-		if projectInfo.Tag != "" {
-			dockerTag = projectInfo.Tag
-		} else {
-			dockerTag = projectInfo.Sha
-		}
-	}
-
 	templateHelmChart := template.NewTemplateHelmChartTask(
 		fs,
 		chartDir,
-		dockerTag,
 		projectInfo.Sha,
 		projectInfo.Version,
 	)


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/6557

This is too confusing to have `.DockerTag` and `.Version` when templating helm charts, so we decided to only have `.Version` which we use to tag the docker image and the chart. So everything get the same version tag.
Simplicity is beauty 🌟 

⚠️ Do not merge before `.DockerTag` is removed from aws-operator and azure-operator helm charts.