### PR TITLE
Use latest Go (1.12.9)

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -57,7 +57,7 @@ func init() {
 	buildCmd.Flags().StringVar(&helmDirectoryPath, "helm-directory-path", "./helm", "directory holding helm chart")
 
 	buildCmd.Flags().StringVar(&golangImage, "golang-image", "quay.io/giantswarm/golang", "golang image")
-	buildCmd.Flags().StringVar(&golangVersion, "golang-version", "1.11.3", "golang version")
+	buildCmd.Flags().StringVar(&golangVersion, "golang-version", "1.12.9", "golang version")
 }
 
 func runBuild(cmd *cobra.Command, args []string) {

--- a/tasks/docker_test.go
+++ b/tasks/docker_test.go
@@ -20,7 +20,7 @@ func TestNewDockerTask(t *testing.T) {
 					"GOOS=linux",
 				},
 				WorkingDirectory: "/go/src/github.com/giantswarm/architect",
-				Image:            "golang:1.7.5",
+				Image:            "golang:1.12.9",
 				Args:             []string{"go", "test"},
 			},
 			expectedArgs: []string{
@@ -28,7 +28,7 @@ func TestNewDockerTask(t *testing.T) {
 				"-v", "/home/ubuntu/architect:/go/src/github.com/giantswarm/architect",
 				"-e", "GOOS=linux",
 				"-w", "/go/src/github.com/giantswarm/architect",
-				"golang:1.7.5",
+				"golang:1.12.9",
 				"go", "test",
 			},
 		},


### PR DESCRIPTION
Upgrading from Go 1.11.x to 1.12.x brought up issues with
`prometheus-config-controller` tests and this was a good catch. Therefore
upgrading latest compiler to be the default in CI as well is a good thing.

Required retagged image PR is here: https://github.com/giantswarm/retagger/pull/243