### PR TITLE
set default version to 0.0.0 instead of 1.0.0

### DIFF
--- a/cmd/hook/preRunE.go
+++ b/cmd/hook/preRunE.go
@@ -49,13 +49,13 @@ func PreRunE(cmd *cobra.Command, args []string) error {
 		// version can be of three different formats:
 		//   2.0.0: building a tagged version.
 		//   2.0.0-3a955cbb126f0fe5d51aedf2eb84acca7b074374: building ahead of a tagged version.
-		//   1.0.0-939f5c6949f83c0a7ea98a25bc9524fd2f751ffe: building a repo which has no tags.
+		//   0.0.0-939f5c6949f83c0a7ea98a25bc9524fd2f751ffe: building a repo which has no tags.
 		if defaultTag != "" {
 			defaultVersion = defaultTag
 		} else {
 			out, err := exec.Command("git", "describe", "--tags", "--abbrev=0", "HEAD").Output()
 			if err != nil {
-				defaultVersion = fmt.Sprintf("1.0.0-%s", defaultSha)
+				defaultVersion = fmt.Sprintf("0.0.0-%s", defaultSha)
 			} else {
 				defaultVersion = fmt.Sprintf("%s-%s", strings.TrimPrefix(strings.TrimSpace(string(out)), "v"), defaultSha)
 			}


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/7044

We no longer want to set default version to `1.0.0` but instead use `0.0.0`.

NOTE: tag aws-operator with v1.0.0 before merging this.