### PR TITLE
Revert "add operator-week-app-collection"

### DIFF
--- a/events/events.go
+++ b/events/events.go
@@ -32,7 +32,6 @@ var (
 		"kubernetesd",
 		"net-exporter",
 		"node-operator",
-		"operator-week-app-collection",
 		"passage",
 		"release-operator",
 		"tokend",


### PR DESCRIPTION
Reverts giantswarm/architect#355

Towards https://github.com/giantswarm/giantswarm/issues/8207

Operator week hackathon operators destabilized test installations - removing operator-week-app-collection while it's still easy.