### PR TITLE
Revert #359

### DIFF
--- a/workflow/helm.go
+++ b/workflow/helm.go
@@ -5,11 +5,11 @@ import (
 	"os/user"
 	"path/filepath"
 
-	"github.com/giantswarm/microerror"
 	"github.com/spf13/afero"
 
 	"github.com/giantswarm/architect/tasks"
 	"github.com/giantswarm/architect/template"
+	"github.com/giantswarm/microerror"
 )
 
 const (

--- a/workflow/workflow.go
+++ b/workflow/workflow.go
@@ -3,17 +3,16 @@ package workflow
 import (
 	"fmt"
 	"io/ioutil"
-	"os"
 	"path/filepath"
 	"strings"
 	"time"
 
 	"github.com/cenk/backoff"
+	"github.com/giantswarm/architect/tasks"
 	"github.com/giantswarm/microerror"
 	"github.com/google/go-github/github"
-	"github.com/spf13/afero"
 
-	"github.com/giantswarm/architect/tasks"
+	"github.com/spf13/afero"
 )
 
 type Workflow []tasks.Task
@@ -186,15 +185,12 @@ func NewBuild(projectInfo ProjectInfo, fs afero.Fs) (Workflow, error) {
 		}
 	}
 
-	branch, ok := os.LookupEnv("CIRCLE_BRANCH")
-	if !ok || branch == "master" {
-		helmTasks, err := processHelmDir(fs, projectInfo, NewHelmPushTask)
-		if err != nil {
-			return nil, microerror.Mask(err)
-		}
-
-		w = append(w, helmTasks...)
+	helmTasks, err := processHelmDir(fs, projectInfo, NewHelmPushTask)
+	if err != nil {
+		return nil, microerror.Mask(err)
 	}
+
+	w = append(w, helmTasks...)
 
 	return w, nil
 }

--- a/workflow/workflow_test.go
+++ b/workflow/workflow_test.go
@@ -2,7 +2,6 @@ package workflow
 
 import (
 	"fmt"
-	"os"
 	"path/filepath"
 	"reflect"
 	"strings"
@@ -379,17 +378,6 @@ func TestGetBuildWorkflow(t *testing.T) {
 			},
 		},
 	}
-
-	// Build task won't push the chart to the registry when on a branch other than master, so we need to
-	// unset the CIRCLE_BRANCH which is set while running this own repository CI.
-	currentBranch := os.Getenv("CIRCLE_BRANCH")
-	if err := os.Unsetenv("CIRCLE_BRANCH"); err != nil {
-		t.Fatalf("unexpected error during setup: %#v", err)
-	}
-
-	defer func() {
-		os.Setenv("CIRCLE_BRANCH", currentBranch)
-	}()
 
 	for i, tc := range tests {
 		fs := afero.NewOsFs()


### PR DESCRIPTION
This was a feature used to push the helm chart to the registry while working on operators branches. That made possible to deploy the operator chart to run e2e tests.

We need to find a way to make the apiextensions repository to push the helm charts using sha instead of always overwritting `0.1.0`. 