### PR TITLE
cmd, workflow: stop injecting version into build info

### DIFF
--- a/workflow/golang.go
+++ b/workflow/golang.go
@@ -64,7 +64,6 @@ func NewGoBuildTask(fs afero.Fs, projectInfo ProjectInfo) (tasks.Task, error) {
 					fmt.Sprintf("-X 'main.gitCommit=%s'", projectInfo.Sha),
 					fmt.Sprintf("-X 'github.com/%s/%s/pkg/project.buildTimestamp=%s'", projectInfo.Organisation, projectInfo.Project, projectInfo.BuildTimestamp.UTC().Format(time.RFC3339)),
 					fmt.Sprintf("-X 'github.com/%s/%s/pkg/project.gitSHA=%s'", projectInfo.Organisation, projectInfo.Project, projectInfo.Sha),
-					fmt.Sprintf("-X 'github.com/%s/%s/pkg/project.version=%s'", projectInfo.Organisation, projectInfo.Project, projectInfo.Version),
 				}, " "),
 			},
 		},

--- a/workflow/golang_test.go
+++ b/workflow/golang_test.go
@@ -2,6 +2,7 @@ package workflow
 
 import (
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/giantswarm/architect/tasks"
@@ -50,13 +51,14 @@ func TestNewGoBuildTask(t *testing.T) {
 				"-a",
 				"-v",
 				"-ldflags",
-				"-w " +
-					"-linkmode 'auto' " +
-					"-extldflags '-static' " +
-					"-X 'main.gitCommit=e8363ac222255e991c126abe6673cd0f33934ac8' " +
-					"-X 'github.com/giantswarm/architect/pkg/project.buildTimestamp=2019-06-04T12:40:05Z' " +
-					"-X 'github.com/giantswarm/architect/pkg/project.gitSHA=e8363ac222255e991c126abe6673cd0f33934ac8' " +
-					"-X 'github.com/giantswarm/architect/pkg/project.version=test'",
+				strings.Join([]string{
+					"-w",
+					"-linkmode 'auto'",
+					"-extldflags '-static'",
+					"-X 'main.gitCommit=e8363ac222255e991c126abe6673cd0f33934ac8'",
+					"-X 'github.com/giantswarm/architect/pkg/project.buildTimestamp=2019-06-04T12:40:05Z'",
+					"-X 'github.com/giantswarm/architect/pkg/project.gitSHA=e8363ac222255e991c126abe6673cd0f33934ac8'",
+				}, " "),
 			},
 			errorMatcher: nil,
 		},


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/8637

We want to invert how the project version is maintained and instead of
generating it from git data and injecting during the build, we want to
maintain it in source files. This will allow managing releases by
merging PRs and that they'll undergo a review process.