### PR TITLE
helmtemplate: Add branch name to template context

### DIFF
--- a/cmd/helm/template/runner.go
+++ b/cmd/helm/template/runner.go
@@ -13,6 +13,7 @@ import (
 func runTemplateError(cmd *cobra.Command, args []string) error {
 	var (
 		chartDir = cmd.Flag("dir").Value.String()
+		branch   = cmd.Flag("branch").Value.String()
 		sha      = cmd.Flag("sha").Value.String()
 		tag      = cmd.Flag("tag").Value.String()
 		version  = cmd.Flag("version").Value.String()
@@ -28,6 +29,7 @@ func runTemplateError(cmd *cobra.Command, args []string) error {
 		c := helmtemplate.Config{
 			Fs:       fs,
 			ChartDir: chartDir,
+			Branch:   branch,
 			Sha:      sha,
 			Version:  version,
 		}

--- a/helmtemplate/helm.go
+++ b/helmtemplate/helm.go
@@ -26,6 +26,7 @@ type TemplateHelmChartTask struct {
 	fs afero.Fs
 
 	chartDir string
+	branch   string
 	sha      string
 	version  string
 }
@@ -35,6 +36,7 @@ type Config struct {
 	Fs afero.Fs
 
 	ChartDir string
+	Branch   string
 	Sha      string
 	Version  string
 }
@@ -49,6 +51,7 @@ func (t TemplateHelmChartTask) Run() error {
 		}
 
 		buildInfo := BuildInfo{
+			Branch:  t.branch,
 			SHA:     t.sha,
 			Version: t.version,
 		}
@@ -84,6 +87,10 @@ func NewTemplateHelmChartTask(config Config) (*TemplateHelmChartTask, error) {
 		return nil, microerror.Maskf(invalidConfigError, "%T.ChartDir must not be empty", config)
 	}
 
+	if config.Branch == "" {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Branch must not be empty", config)
+	}
+
 	if config.Sha == "" {
 		return nil, microerror.Maskf(invalidConfigError, "%T.Sha must not be empty", config)
 	}
@@ -95,6 +102,7 @@ func NewTemplateHelmChartTask(config Config) (*TemplateHelmChartTask, error) {
 	t := &TemplateHelmChartTask{
 		fs:       config.Fs,
 		chartDir: config.ChartDir,
+		branch:   config.Branch,
 		sha:      config.Sha,
 		version:  config.Version,
 	}

--- a/helmtemplate/helm_test.go
+++ b/helmtemplate/helm_test.go
@@ -13,6 +13,7 @@ import (
 func TestTemplateHelmChartTask(t *testing.T) {
 	tests := []struct {
 		chartDir string
+		branch   string
 		sha      string
 		version  string
 		setUp    func(afero.Fs, string) error
@@ -21,6 +22,7 @@ func TestTemplateHelmChartTask(t *testing.T) {
 		// Test that a chart is templated correctly.
 		{
 			chartDir: "/helm/test-chart",
+			branch:   "beamish-boy",
 			sha:      "jabberwocky",
 			version:  "mad-hatter",
 			setUp: func(fs afero.Fs, chartDir string) error {
@@ -34,7 +36,7 @@ func TestTemplateHelmChartTask(t *testing.T) {
 					},
 					{
 						path: filepath.Join(chartDir, HelmValuesYamlName),
-						data: "Version: [[ .Version ]]",
+						data: "Branch: [[ .Branch ]]\nVersion: [[ .Version ]]",
 					},
 				}
 
@@ -63,7 +65,7 @@ func TestTemplateHelmChartTask(t *testing.T) {
 					},
 					{
 						path: filepath.Join(chartDir, HelmValuesYamlName),
-						data: "Version: mad-hatter",
+						data: "Branch: beamish-boy\nVersion: mad-hatter",
 					},
 				}
 
@@ -87,6 +89,7 @@ func TestTemplateHelmChartTask(t *testing.T) {
 		task, err := NewTemplateHelmChartTask(Config{
 			Fs:       fs,
 			ChartDir: test.chartDir,
+			Branch:   test.branch,
 			Sha:      test.sha,
 			Version:  test.version,
 		})

--- a/helmtemplate/types.go
+++ b/helmtemplate/types.go
@@ -12,6 +12,8 @@ var (
 
 // BuildInfo holds information concerning the current build.
 type BuildInfo struct {
+	// Branch is the name of the branch we're building.
+	Branch string
 	// SHA is the SHA-1 tag of the commit we are building for.
 	SHA string
 	// Version is the version of the commit being built.


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/8632

Add Git branch name to context data used when templating Helm charts.
It's already available as a flag but previously wasn't exposed to the
template. We now want to include it to be able to expose it via a label
on the resources created by the template.