### PR TITLE
Update to golang 1.14.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM quay.io/giantswarm/helm-chart-testing:v2.4.0 AS ct
 
 RUN pip freeze > /helm-chart-testing-py-requirements.txt
 
-FROM quay.io/giantswarm/golang:1.14.0-alpine3.11 AS golang
+FROM quay.io/giantswarm/golang:1.14.1-alpine3.11 AS golang
 
 # Build Image
 FROM quay.io/giantswarm/alpine:3.11

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,10 +2,10 @@ FROM quay.io/giantswarm/helm-chart-testing:v2.4.0 AS ct
 
 RUN pip freeze > /helm-chart-testing-py-requirements.txt
 
-FROM quay.io/giantswarm/golang:1.13.1-alpine3.10 AS golang
+FROM quay.io/giantswarm/golang:1.14.0-alpine3.11 AS golang
 
 # Build Image
-FROM quay.io/giantswarm/alpine:3.10
+FROM quay.io/giantswarm/alpine:3.11
 
 # Copy go from golang image.
 COPY --from=golang /usr/local/go /usr/local/go
@@ -19,7 +19,7 @@ COPY --from=ct /etc/ct/lintconf.yaml /etc/ct/lintconf.yaml
 ENV GOPATH /go
 ENV PATH $GOPATH/bin:/usr/local/go/bin:$PATH
 
-ARG HELM_VERSION=v2.14.3
+ARG HELM_VERSION=v2.16.3
 
 RUN apk add --no-cache \
         bash \

--- a/cmd/build.go
+++ b/cmd/build.go
@@ -59,7 +59,7 @@ func init() {
 	buildCmd.Flags().StringVar(&helmDirectoryPath, "helm-directory-path", "./helm", "directory holding helm chart")
 
 	buildCmd.Flags().StringVar(&golangImage, "golang-image", "quay.io/giantswarm/golang", "golang image")
-	buildCmd.Flags().StringVar(&golangVersion, "golang-version", "1.14.0", "golang version")
+	buildCmd.Flags().StringVar(&golangVersion, "golang-version", "1.14.1", "golang version")
 }
 
 func runBuild(cmd *cobra.Command, args []string) {

--- a/cmd/build.go
+++ b/cmd/build.go
@@ -57,7 +57,7 @@ func init() {
 	buildCmd.Flags().StringVar(&helmDirectoryPath, "helm-directory-path", "./helm", "directory holding helm chart")
 
 	buildCmd.Flags().StringVar(&golangImage, "golang-image", "quay.io/giantswarm/golang", "golang image")
-	buildCmd.Flags().StringVar(&golangVersion, "golang-version", "1.13.1", "golang version")
+	buildCmd.Flags().StringVar(&golangVersion, "golang-version", "1.14.0", "golang version")
 }
 
 func runBuild(cmd *cobra.Command, args []string) {

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/giantswarm/architect
 
-go 1.13
+go 1.14
 
 require (
 	github.com/Masterminds/semver v1.5.0 // indirect

--- a/tasks/docker_test.go
+++ b/tasks/docker_test.go
@@ -20,7 +20,7 @@ func TestNewDockerTask(t *testing.T) {
 					"GOOS=linux",
 				},
 				WorkingDirectory: "/go/src/github.com/giantswarm/architect",
-				Image:            "golang:1.13.1",
+				Image:            "golang:1.14.0",
 				Args:             []string{"go", "test"},
 			},
 			expectedArgs: []string{
@@ -28,7 +28,7 @@ func TestNewDockerTask(t *testing.T) {
 				"-v", "/home/ubuntu/architect:/go/src/github.com/giantswarm/architect",
 				"-e", "GOOS=linux",
 				"-w", "/go/src/github.com/giantswarm/architect",
-				"golang:1.13.1",
+				"golang:1.14.0",
 				"go", "test",
 			},
 		},

--- a/tasks/docker_test.go
+++ b/tasks/docker_test.go
@@ -20,7 +20,7 @@ func TestNewDockerTask(t *testing.T) {
 					"GOOS=linux",
 				},
 				WorkingDirectory: "/go/src/github.com/giantswarm/architect",
-				Image:            "golang:1.14.0",
+				Image:            "golang:1.14.1",
 				Args:             []string{"go", "test"},
 			},
 			expectedArgs: []string{
@@ -28,7 +28,7 @@ func TestNewDockerTask(t *testing.T) {
 				"-v", "/home/ubuntu/architect:/go/src/github.com/giantswarm/architect",
 				"-e", "GOOS=linux",
 				"-w", "/go/src/github.com/giantswarm/architect",
-				"golang:1.14.0",
+				"golang:1.14.1",
 				"go", "test",
 			},
 		},


### PR DESCRIPTION
There are quite a few significant changes [in 1.14](https://blog.golang.org/go1.14) including performance improvements, and I think it's best if we don't get too far behind on our versions. We use the latest release of `architect` in many places so we'll need to do some testing before actually merging this PR. I just wanted to get the conversation started about whether/when we should upgrade.

Build error should be fixed once https://github.com/giantswarm/retagger/pull/384 is merged.