### PR TITLE
Add binary install of golangci-lint to architect image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,7 @@ ENV GOPATH /go
 ENV PATH $GOPATH/bin:/usr/local/go/bin:$PATH
 
 ARG HELM_VERSION=v2.14.3
+ARG GOLANGCI_LINT_VERSION=v1.23.8
 
 RUN apk add --no-cache \
         bash \
@@ -30,7 +31,9 @@ RUN apk add --no-cache \
         py-pip \
         openssh-client &&\
         curl -SL https://storage.googleapis.com/kubernetes-helm/helm-${HELM_VERSION}-linux-amd64.tar.gz | \
-            tar -C /usr/bin --strip-components 1 -xvzf - linux-amd64/helm
+            tar -C /usr/bin --strip-components 1 -xvzf - linux-amd64/helm && \
+        curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | \
+            sh -s -- -b $GOPATH/bin ${GOLANGCI_LINT_VERSION}
 
 # Setup ssh config for github.com
 RUN mkdir ~/.ssh &&\


### PR DESCRIPTION
Rather than setting up remote docker and pulling a separate image on every scan, add the linting tool directly to the architect image and use in-place. Supports https://github.com/giantswarm/architect-orb/pull/87

Toward https://github.com/giantswarm/giantswarm/issues/8901 https://github.com/giantswarm/giantswarm/issues/7658