### PR TITLE
Install conftest and policies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ RUN pip freeze > /helm-chart-testing-py-requirements.txt
 
 FROM quay.io/giantswarm/golang:1.13.1-alpine3.10 AS golang
 
-FROM instrumenta/conftest:v0.18.1 AS conftest
+FROM quay.io/giantswarm/conftest:v0.18.1 AS conftest
 
 # Build Image
 FROM quay.io/giantswarm/alpine:3.10

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,7 @@ COPY --from=ct /etc/ct/lintconf.yaml /etc/ct/lintconf.yaml
 
 ENV GOPATH /go
 ENV PATH $GOPATH/bin:/usr/local/go/bin:$PATH
+ENV CONFTEST_POLICIES /etc/policies
 
 ARG HELM_VERSION=v2.14.3
 ARG GOLANGCI_LINT_VERSION=v1.23.8
@@ -36,7 +37,8 @@ RUN apk add --no-cache \
         curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | \
             sh -s -- -b $GOPATH/bin ${GOLANGCI_LINT_VERSION} && \
         curl -SL https://github.com/instrumenta/conftest/releases/download/v${CONFTEST_VERSION}/conftest_${CONFTEST_VERSION}_Linux_x86_64.tar.gz | \
-            tar -C /usr/bin --strip-components 1 -xvzf - conftest
+            tar -C /usr/bin --strip-components 1 -xvzf - conftest && \
+        git clone https://github.com/swade1987/deprek8ion.git ${CONFTEST_POLICIES}
 
 # Setup ssh config for github.com
 RUN mkdir ~/.ssh &&\

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,6 @@ COPY --from=conftest /usr/local/bin/conftest /usr/local/bin/conftest
 
 ENV GOPATH /go
 ENV PATH $GOPATH/bin:/usr/local/go/bin:$PATH
-ENV CONFTEST_POLICIES /etc/policies
 
 ARG HELM_VERSION=v2.14.3
 ARG GOLANGCI_LINT_VERSION=v1.23.8
@@ -38,8 +37,7 @@ RUN apk add --no-cache \
         curl -SL https://storage.googleapis.com/kubernetes-helm/helm-${HELM_VERSION}-linux-amd64.tar.gz | \
             tar -C /usr/bin --strip-components 1 -xvzf - linux-amd64/helm && \
         curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | \
-            sh -s -- -b $GOPATH/bin ${GOLANGCI_LINT_VERSION} && \
-        git clone https://github.com/swade1987/deprek8ion.git ${CONFTEST_POLICIES}
+            sh -s -- -b $GOPATH/bin ${GOLANGCI_LINT_VERSION}
 
 # Setup ssh config for github.com
 RUN mkdir ~/.ssh &&\

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,7 @@ ENV PATH $GOPATH/bin:/usr/local/go/bin:$PATH
 
 ARG HELM_VERSION=v2.14.3
 ARG GOLANGCI_LINT_VERSION=v1.23.8
+ARG CONFTEST_VERSION=0.18.1
 
 RUN apk add --no-cache \
         bash \
@@ -33,7 +34,9 @@ RUN apk add --no-cache \
         curl -SL https://storage.googleapis.com/kubernetes-helm/helm-${HELM_VERSION}-linux-amd64.tar.gz | \
             tar -C /usr/bin --strip-components 1 -xvzf - linux-amd64/helm && \
         curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | \
-            sh -s -- -b $GOPATH/bin ${GOLANGCI_LINT_VERSION}
+            sh -s -- -b $GOPATH/bin ${GOLANGCI_LINT_VERSION} && \
+        curl -SL https://github.com/instrumenta/conftest/releases/download/v${CONFTEST_VERSION}/conftest_${CONFTEST_VERSION}_Linux_x86_64.tar.gz | \
+            tar -C /usr/bin --strip-components 1 -xvzf - conftest
 
 # Setup ssh config for github.com
 RUN mkdir ~/.ssh &&\


### PR DESCRIPTION
Installing conftest would allow us to check our kubernetes manifests / helm charts using OPA policies.

PoC

![image](https://user-images.githubusercontent.com/627038/77857190-60537180-71fc-11ea-8666-ac1e089b752f.png)


When changing `Deployment` api version

![image](https://user-images.githubusercontent.com/627038/77884265-020ea900-7265-11ea-8120-9a344f743ae1.png)
