### PR TITLE
events: remove app-operator from the project list

### DIFF
--- a/events/events.go
+++ b/events/events.go
@@ -13,7 +13,6 @@ var (
 	// services used in all our installations
 	baseProjectList = []string{
 		"api",
-		"app-operator",
 		"cert-exporter",
 		"cert-operator",
 		"chart-operator",


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/9040

See https://github.com/giantswarm/app-operator/pull/238.

It will be deployed via collection.