### PR TITLE
Removing app-operator from deployment

### DIFF
--- a/events/events.go
+++ b/events/events.go
@@ -13,7 +13,6 @@ var (
 	// services used in all our installations
 	baseProjectList = []string{
 		"api",
-		"app-operator",
 		"cert-exporter",
 		"cert-operator",
 		"cluster-operator",


### PR DESCRIPTION
Toward https://github.com/giantswarm/giantswarm/issues/7895

Removing app-operator from draughtsman. 