### PR TITLE
remove cert-operator from baseProjectList

### DIFF
--- a/events/events.go
+++ b/events/events.go
@@ -15,7 +15,6 @@ var (
 		"api",
 		"app-operator",
 		"cert-exporter",
-		"cert-operator",
 		"cluster-operator",
 		"cluster-service",
 		"companyd",


### PR DESCRIPTION
After https://github.com/giantswarm/giantswarm/issues/9339 cert-operator
will be pushed to _aws_, _kvm_ and _azure_ app catalogs. This makes its
`baseProjectList` entry obsolete.