### PR TITLE
Update giantswarm/app to 0.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
-## Unreleased
+## [Unreleased]
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## Unreleased
+
+### Changed
+
+- Updated `giantswarm/app` dependency to 0.2.1 (first go-modules version).
 
 ## [1.0.0] 2020-04-23
 
@@ -14,4 +19,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add changelog.
 - Add SemVer versioning.
 
-[1.0.0]: https://github.com/giantswarm/aws-operator/releases/tag/v1.0.0
+[Unreleased]: https://github.com/giantswarm/architect/compare/v1.0.0...HEAD
+[1.0.0]: https://github.com/giantswarm/architect/releases/tag/v1.0.0

--- a/go.mod
+++ b/go.mod
@@ -7,8 +7,7 @@ require (
 	github.com/cenk/backoff v2.2.1+incompatible
 	github.com/cyphar/filepath-securejoin v0.2.2 // indirect
 	github.com/ghodss/yaml v1.0.0 // indirect
-	github.com/giantswarm/apiextensions v0.3.0 // indirect
-	github.com/giantswarm/app v0.0.0-20200422085056-5548fb4557e6
+	github.com/giantswarm/app v0.2.1
 	github.com/giantswarm/gitrepo v0.1.1
 	github.com/giantswarm/microerror v0.2.0
 	github.com/gobwas/glob v0.2.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -82,10 +82,10 @@ github.com/ghodss/yaml v0.0.0-20150909031657-73d445a93680/go.mod h1:4dBDuWmgqj2H
 github.com/ghodss/yaml v0.0.0-20180820084758-c7ce16629ff4/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/ghodss/yaml v1.0.0 h1:wQHKEahhL6wmXdzwWG11gIVCkOv05bNOh+Rxn0yngAk=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
-github.com/giantswarm/apiextensions v0.3.0 h1:Vr6UUMr9GxX00510tILX4gQi5KMbZL+rNBFQ68eYyKo=
-github.com/giantswarm/apiextensions v0.3.0/go.mod h1:zv0VvUDPUuLOcSJA+DAGxisg3PP5y6EiLaGRieedqMQ=
-github.com/giantswarm/app v0.0.0-20200422085056-5548fb4557e6 h1:BF0l1fRhfkZbpTdhC1h98hFTatyjewXKMP4HG72dx1U=
-github.com/giantswarm/app v0.0.0-20200422085056-5548fb4557e6/go.mod h1:FbNnL5ix7xsvgV793ZBQMpu7Dy3l/09XhINhImjznRQ=
+github.com/giantswarm/apiextensions v0.3.1 h1:hjqvl1W775Tl6uTuvcw9ZE4VFiEsnS+BehUgmEIfGdQ=
+github.com/giantswarm/apiextensions v0.3.1/go.mod h1:zv0VvUDPUuLOcSJA+DAGxisg3PP5y6EiLaGRieedqMQ=
+github.com/giantswarm/app v0.2.1 h1:5ZxgMCMLhj4MwN/jBVIwcGmA5bG9q9oPknhG5C/ogQc=
+github.com/giantswarm/app v0.2.1/go.mod h1:eWEc1CK7EvTpEZ1pocXI0Ih/Y7O4uX4yLwLwZI2KFsk=
 github.com/giantswarm/gitrepo v0.1.1 h1:ihFZ632VNFLQDOEgV17zc+8K43ZSJ59yY5wb+7JnhT4=
 github.com/giantswarm/gitrepo v0.1.1/go.mod h1:V80tQA1a3SjFDQKXSiiA5F3k/0A3VK5SwGzkoV2RwlI=
 github.com/giantswarm/microerror v0.0.0-20190815145748-cb07ec533b50 h1:QvSOi2v0Ks/B4chcyvlcb7RTZOQEebaHgdXEfunT9Mk=
@@ -158,6 +158,8 @@ github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7a
 github.com/gogo/protobuf v1.2.1/go.mod h1:hp+jE20tsWTFYpLwKvXlhS1hjn+gTNwPg2I6zVXpSg4=
 github.com/gogo/protobuf v1.2.2-0.20190723190241-65acae22fc9d h1:3PaI8p3seN09VjbTYC/QWlUZdZ1qS1zGjy7LH2Wt07I=
 github.com/gogo/protobuf v1.2.2-0.20190723190241-65acae22fc9d/go.mod h1:SlYgWuQ5SjCEi6WLHjHCa1yvBfUnHcTbrrZtXPKa29o=
+github.com/gogo/protobuf v1.3.1 h1:DqDEcV5aeaTmdFBePNpYsp3FlcVH/2ISVVM9Qf8PSls=
+github.com/gogo/protobuf v1.3.1/go.mod h1:SlYgWuQ5SjCEi6WLHjHCa1yvBfUnHcTbrrZtXPKa29o=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/groupcache v0.0.0-20160516000752-02826c3e7903/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/groupcache v0.0.0-20180513044358-24b0969c4cb7/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
@@ -537,6 +539,8 @@ k8s.io/utils v0.0.0-20190506122338-8fab8cb257d5/go.mod h1:sZAwmy6armz5eXlNoLmJcl
 k8s.io/utils v0.0.0-20190801114015-581e00157fb1/go.mod h1:sZAwmy6armz5eXlNoLmJcl4F1QuKu7sr+mFQ0byX7Ew=
 k8s.io/utils v0.0.0-20190809000727-6c36bc71fc4a h1:uy5HAgt4Ha5rEMbhZA+aM1j2cq5LmR6LQ71EYC2sVH4=
 k8s.io/utils v0.0.0-20190809000727-6c36bc71fc4a/go.mod h1:sZAwmy6armz5eXlNoLmJcl4F1QuKu7sr+mFQ0byX7Ew=
+k8s.io/utils v0.0.0-20191114200735-6ca3b61696b6 h1:p0Ai3qVtkbCG/Af26dBmU0E1W58NID3hSSh7cMyylpM=
+k8s.io/utils v0.0.0-20191114200735-6ca3b61696b6/go.mod h1:sZAwmy6armz5eXlNoLmJcl4F1QuKu7sr+mFQ0byX7Ew=
 modernc.org/cc v1.0.0/go.mod h1:1Sk4//wdnYJiUIxnW8ddKpaOJCF37yAdqYnkxUpaYxw=
 modernc.org/golex v1.0.0/go.mod h1:b/QX9oBD/LhixY6NDh+IdGv17hgB+51fET1i2kPSmvk=
 modernc.org/mathutil v1.0.0/go.mod h1:wU0vUrJsVWBZ4P6e7xtFJEhFSNsfRLJ8H458uRjg03k=


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/10272.

This is the version released after migrating to go modules, which makes
the `go.mod`, etc. tidier.