### PR TITLE
Ensure AppVersion for repos without pkg/project

### DIFF
--- a/cmd/helm/template/runner.go
+++ b/cmd/helm/template/runner.go
@@ -55,6 +55,11 @@ func runTemplateError(cmd *cobra.Command, args []string) (err error) {
 		if err != nil {
 			return microerror.Mask(err)
 		}
+
+		// for repositories without pkg/project/project.go
+		if appVersion == "" {
+			appVersion = version
+		}
 	}
 
 	log.Printf("templating helm chart\ndir: %s\nsha: %s\ntag: %s\napp-version: %s\nversion: %s\n", chartDir, sha, tag, appVersion, version)


### PR DESCRIPTION
AppVersion value in Chart.yaml will not be rendered for repositories which do not have pkg/project/project.go. Let's assign Version value to AppVersion in this case.

Fixes https://github.com/giantswarm/giantswarm/issues/10270