### PR TITLE
Skip AppVersion check when project file is absent

### DIFF
--- a/cmd/helm/template/runner.go
+++ b/cmd/helm/template/runner.go
@@ -45,6 +45,7 @@ func runTemplateError(cmd *cobra.Command, args []string) (err error) {
 	ctx := context.Background()
 
 	var appVersion string
+	skipAppVersionCheck := false
 	{
 		dir, err := gitrepo.TopLevel(ctx, ".")
 		if err != nil {
@@ -59,6 +60,7 @@ func runTemplateError(cmd *cobra.Command, args []string) (err error) {
 		// for repositories without pkg/project/project.go
 		if appVersion == "" {
 			appVersion = version
+			skipAppVersionCheck = true
 		}
 	}
 
@@ -67,12 +69,13 @@ func runTemplateError(cmd *cobra.Command, args []string) (err error) {
 	var s *helmtemplate.TemplateHelmChartTask
 	{
 		c := helmtemplate.Config{
-			Fs:         fs,
-			ChartDir:   chartDir,
-			Branch:     branch,
-			Sha:        sha,
-			Version:    version,
-			AppVersion: appVersion,
+			Fs:                  fs,
+			ChartDir:            chartDir,
+			Branch:              branch,
+			Sha:                 sha,
+			Version:             version,
+			AppVersion:          appVersion,
+			SkipAppVersionCheck: skipAppVersionCheck,
 		}
 
 		s, err = helmtemplate.NewTemplateHelmChartTask(c)

--- a/helmtemplate/helm.go
+++ b/helmtemplate/helm.go
@@ -50,7 +50,8 @@ type Config struct {
 func (t TemplateHelmChartTask) Run(validate, tagBuild bool) error {
 	// We expect versions to match for a tagged build if pkg/project/project.go
 	// file has been found. Otherwise (project.go not found) t.appVersion will
-	// be empty.
+	// be empty, which will always be the case for Managed Apps as appVersion will
+	// refer to the version of the application being installed.
 	if validate && tagBuild && t.appVersion != "" && t.chartVersion != t.appVersion && !t.skipAppVersionCheck {
 		return microerror.Maskf(
 			validationFailedError,


### PR DESCRIPTION
Managed apps do not have any go project files and the AppVersion in this
case refers to the version deployed by Helm. Not linked to any particular
project.

If project.go is not present or when checking for appVersion
in the project files returns an empty string then skip the validation checks.

Slack thread related to this commit:
https://gigantic.slack.com/archives/CRZN9GLJW/p1588605374410900