### PR TITLE
Revert "Removing app-operator from deployment (#407)"

### DIFF
--- a/events/events.go
+++ b/events/events.go
@@ -13,6 +13,7 @@ var (
 	// services used in all our installations
 	baseProjectList = []string{
 		"api",
+		"app-operator",
 		"cert-exporter",
 		"cluster-operator",
 		"credentiald",


### PR DESCRIPTION
This reverts commit 9af8772e7a40ef7c5c75e4671faf315d5d2b7205.

Toward https://github.com/giantswarm/giantswarm/issues/10798

We need to bring `app-operator` with thiccc branch running in CPs. 