### PR TITLE
Upgrade helm to 3.2.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ COPY --from=conftest /usr/local/bin/conftest /usr/local/bin/conftest
 ENV GOPATH /go
 ENV PATH $GOPATH/bin:/usr/local/go/bin:$PATH
 
-ARG HELM_VERSION=v2.16.3
+ARG HELM_VERSION=v3.2.4
 ARG GOLANGCI_LINT_VERSION=v1.23.8
 
 RUN apk add --no-cache \
@@ -34,7 +34,7 @@ RUN apk add --no-cache \
         git \
         py-pip \
         openssh-client &&\
-        curl -SL https://storage.googleapis.com/kubernetes-helm/helm-${HELM_VERSION}-linux-amd64.tar.gz | \
+        curl -SL https://get.helm.sh/helm-${HELM_VERSION}-linux-amd64.tar.gz | \
             tar -C /usr/bin --strip-components 1 -xvzf - linux-amd64/helm && \
         curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | \
             sh -s -- -b $GOPATH/bin ${GOLANGCI_LINT_VERSION}


### PR DESCRIPTION
Helm in architect should be upgraded to 3.2.4 to recognize helm 3 functions. (e.g. `lookup`)