### PR TITLE
Update go.mod when preparing release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-
 ## [Unreleased]
+
+### Added
+
+- Update module line in go.mod file (if it exists) when major version is bigger
+  than 1 in `preapare-release` command.
 
 ## [1.2.0] - 2020-06-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Update module line in go.mod file (if it exists) when major version is bigger
-  than 1 in `preapare-release` command.
+  than 1 in `prepare-release` command.
 
 ## [1.2.0] - 2020-06-08
 

--- a/cmd/preparerelease/internal/funcs.go
+++ b/cmd/preparerelease/internal/funcs.go
@@ -30,7 +30,7 @@ func validateSingleOccurrence(data []byte, regexps ...*regexp.Regexp) error {
 	}
 
 	if matches == 0 {
-		return microerror.Maskf(executionFailedError, "no match for pattern %#q match found in data:\n---\n%s\n---", combined, data)
+		return microerror.Maskf(executionFailedError, "no match for pattern %#q found in data:\n---\n%s\n---", combined, data)
 	}
 	if matches > 1 {
 		return microerror.Maskf(executionFailedError, "%d pattern %#q matches found, expected 1 in data:\n---\n%s\n---", matches, combined, data)

--- a/cmd/preparerelease/internal/key.go
+++ b/cmd/preparerelease/internal/key.go
@@ -2,5 +2,6 @@ package internal
 
 const (
 	FileChangelogMd = "CHANGELOG.md"
+	FileGoMod       = "go.mod"
 	FileProjectGo   = "pkg/project/project.go"
 )

--- a/cmd/preparerelease/internal/modifier.go
+++ b/cmd/preparerelease/internal/modifier.go
@@ -112,6 +112,49 @@ func (m *Modifier) addReleaseToChangelogMd(content []byte) ([]byte, error) {
 	return content, nil
 }
 
+func (m *Modifier) UpdateVersionInGoMod() error {
+	file := FileGoMod
+	modifyFunc := m.updateVersionInGoMod
+
+	err := modifyFile(filepath.Join(m.workingDir, file), modifyFunc)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	return nil
+}
+
+func (m *Modifier) updateVersionInGoMod(content []byte) ([]byte, error) {
+	var err error
+
+	moduleSuffix := "/v" + strings.Split(m.newVersion, ".")[0]
+	if moduleSuffix == "/v0" || moduleSuffix == "/v1" {
+		moduleSuffix = ""
+	}
+
+	// Define replacements.
+
+	// To match strings like:
+	//
+	//	module github.com/giantswarm/architect
+	//	module github.com/giantswarm/architect/v2
+	//
+	module := regexp.MustCompile(`(?m)^(module \S+)(?:/v\d+)?(\s+)$`)
+	moduleReplacement := fmt.Sprintf(`$1%s$2`, moduleSuffix)
+
+	// Validate.
+
+	err = validateSingleOccurrence(content, module)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	// Execute replacements.
+	content = module.ReplaceAll(content, []byte(moduleReplacement))
+
+	return content, nil
+}
+
 func (m *Modifier) UpdateVersionInProjectGo() error {
 	file := FileProjectGo
 	modifyFunc := m.updateVersionInProjectGo

--- a/cmd/preparerelease/runner.go
+++ b/cmd/preparerelease/runner.go
@@ -44,6 +44,15 @@ func runPrepareRelease(cmd *cobra.Command, args []string) error {
 	}
 	cmd.Printf("File %#q updated.\n", internal.FileChangelogMd)
 
+	err = m.UpdateVersionInGoMod()
+	if internal.IsFileNotFound(err) {
+		// Fall trough. Some projects do not have project.go file.
+	} else if err != nil {
+		return microerror.Mask(err)
+	} else {
+		cmd.Printf("File %#q updated.\n", internal.FileProjectGo)
+	}
+
 	err = m.UpdateVersionInProjectGo()
 	if internal.IsFileNotFound(err) {
 		// Fall trough. Some projects do not have project.go file.


### PR DESCRIPTION
If go.mod file exists and version is bigger than v1 it will add a proper `/vN` suffix to module line:

E.g.:

```diff
# In go.mod for: architect prepare-release --version 2.0.0:
- module github.com/giantswarm/architect
+ module github.com/giantswarm/architect/v2
```