### PR TITLE
Handle fix releases like 0.1.0-2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Changed
+### Added
 
 - Handle release versions like `0.1.0-1` in `prepare-release` command.
 - Do not update version in `project.go` file for replacement releases (versions `0.1.0-x`).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Handle release versions like `0.1.0-1` in `prepare-release` command.
+- Do not update version in `project.go` file for replacement releases (versions `0.1.0-x`).
+
 ## [2.1.1] - 2020-08-05
 
 ### Added

--- a/cmd/preparerelease/internal/modifier.go
+++ b/cmd/preparerelease/internal/modifier.go
@@ -183,8 +183,6 @@ func (m *Modifier) updateVersionInProjectGo(content []byte) ([]byte, error) {
 		return content, nil
 	}
 
-	fmt.Println("no match")
-
 	// To match strings like:
 	//
 	//	version = "1.2.3"

--- a/cmd/preparerelease/internal/modifier.go
+++ b/cmd/preparerelease/internal/modifier.go
@@ -74,7 +74,7 @@ func (m *Modifier) addReleaseToChangelogMd(content []byte) ([]byte, error) {
 	//
 	//	[Unreleased]: https://github.com/giantswarm/REPOSITORY_NAME/compare/v1.2.3...HEAD
 	//
-	bottomLinks := regexp.MustCompile(`\[Unreleased\]:\s+https://github.com/\S+/compare/v(\d+\.\d+\.\d+)\.\.\.HEAD\s*`)
+	bottomLinks := regexp.MustCompile(`\[Unreleased\]:\s+https://github.com/\S+/compare/v(\d+\.\d+\.\d(-\d+)?)\.\.\.HEAD\s*`)
 	bottomLinksReplacement := strings.Join([]string{
 		fmt.Sprintf("[Unreleased]: https://github.com/%s/compare/v%s...HEAD", m.repo, m.newVersion),
 		fmt.Sprintf("[%s]: https://github.com/%s/compare/v${1}...v%s", m.newVersion, m.repo, m.newVersion),

--- a/cmd/preparerelease/internal/modifier.go
+++ b/cmd/preparerelease/internal/modifier.go
@@ -174,10 +174,23 @@ func (m *Modifier) updateVersionInProjectGo(content []byte) ([]byte, error) {
 
 	// To match strings like:
 	//
+	// version = "1.2.3-1"
+	//
+	// Skip version update as it must stay the same
+
+	version := regexp.MustCompile(`[0-9]+\.[0-9]+\.[0-9]+-([0-9])+`)
+	if version.MatchString(m.newVersion) {
+		return content, nil
+	}
+
+	fmt.Println("no match")
+
+	// To match strings like:
+	//
 	//	version = "1.2.3"
 	//	version = "1.2.3-any-suffix"
 	//
-	version := regexp.MustCompile(`(version\s*=\s*)"[0-9]+\.[0-9]+\.[0-9]+\S*"`)
+	version = regexp.MustCompile(`(version\s*=\s*)"[0-9]+\.[0-9]+\.[0-9]+\S*"`)
 	versionReplacement := fmt.Sprintf(`$1"%s"`, m.newVersion)
 
 	// Validate.


### PR DESCRIPTION
So we have these kinds of releases like `0.1.0-1` which are used to replace respective release version (e.g. `0.1.0` in this case). 

1. `architect prepare-release` fails to parse flag value when you use such version.
2. if such version is used, `project.go` should not be changed as otherwise e.g. operator is not able to reconcile CRs as it uses wrong version

This PR fixes those cases.