### PR TITLE
Update to Golang 1.15.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Move `deploy` to `legacy deploy` and strip down the functionality to only
   creating GitHub deployment events.
+- Updated `go` version to `v1.15.2`.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Move `deploy` to `legacy deploy` and strip down the functionality to only
   creating GitHub deployment events.
-- Updated `go` version to `v1.15.2`.
+- Update `go` version to `v1.15.2`.
 
 ### Removed
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM quay.io/giantswarm/helm-chart-testing:v3.0.0-rc.1 AS ct
 
 RUN pip freeze > /helm-chart-testing-py-requirements.txt
 
-FROM quay.io/giantswarm/golang:1.14.1-alpine3.11 AS golang
+FROM quay.io/giantswarm/golang:1.15.2-alpine3.12 AS golang
 
 FROM quay.io/giantswarm/conftest:v0.18.1 AS conftest
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/giantswarm/architect
 
-go 1.14
+go 1.15
 
 require (
 	github.com/cenk/backoff v2.2.1+incompatible

--- a/tasks/docker_test.go
+++ b/tasks/docker_test.go
@@ -20,7 +20,7 @@ func TestNewDockerTask(t *testing.T) {
 					"GOOS=linux",
 				},
 				WorkingDirectory: "/go/src/github.com/giantswarm/architect",
-				Image:            "golang:1.14.1",
+				Image:            "golang:1.15.2",
 				Args:             []string{"go", "test"},
 			},
 			expectedArgs: []string{
@@ -28,7 +28,7 @@ func TestNewDockerTask(t *testing.T) {
 				"-v", "/home/ubuntu/architect:/go/src/github.com/giantswarm/architect",
 				"-e", "GOOS=linux",
 				"-w", "/go/src/github.com/giantswarm/architect",
-				"golang:1.14.1",
+				"golang:1.15.2",
 				"go", "test",
 			},
 		},


### PR DESCRIPTION
[Go 1.15 was released last month](https://golang.org/doc/devel/release.html#go1.15). It would be good to be up to date on this. The new go docker image [has been added to rettager](https://github.com/giantswarm/retagger/pull/485).