### PR TITLE
Accept alphanumeric strings for release suffix 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Accept alphanumeric strings for release suffix rather than only numbers in prepare-release command.
+
 ## [3.0.1] - 2020-10-07
 
 ### Added

--- a/cmd/preparerelease/internal/modifier.go
+++ b/cmd/preparerelease/internal/modifier.go
@@ -74,7 +74,7 @@ func (m *Modifier) addReleaseToChangelogMd(content []byte) ([]byte, error) {
 	//
 	//	[Unreleased]: https://github.com/giantswarm/REPOSITORY_NAME/compare/v1.2.3...HEAD
 	//
-	bottomLinks := regexp.MustCompile(`\[Unreleased\]:\s+https://github.com/\S+/compare/v(\d+\.\d+\.\d(-\d+)?)\.\.\.HEAD\s*`)
+	bottomLinks := regexp.MustCompile(`\[Unreleased\]:\s+https://github.com/\S+/compare/v(\d+\.\d+\.\d(-w+)?)\.\.\.HEAD\s*`)
 	bottomLinksReplacement := strings.Join([]string{
 		fmt.Sprintf("[Unreleased]: https://github.com/%s/compare/v%s...HEAD", m.repo, m.newVersion),
 		fmt.Sprintf("[%s]: https://github.com/%s/compare/v${1}...v%s", m.newVersion, m.repo, m.newVersion),

--- a/cmd/preparerelease/internal/modifier.go
+++ b/cmd/preparerelease/internal/modifier.go
@@ -74,7 +74,7 @@ func (m *Modifier) addReleaseToChangelogMd(content []byte) ([]byte, error) {
 	//
 	//	[Unreleased]: https://github.com/giantswarm/REPOSITORY_NAME/compare/v1.2.3...HEAD
 	//
-	bottomLinks := regexp.MustCompile(`\[Unreleased\]:\s+https://github.com/\S+/compare/v(\d+\.\d+\.\d(-w+)?)\.\.\.HEAD\s*`)
+	bottomLinks := regexp.MustCompile(`\[Unreleased\]:\s+https://github.com/\S+/compare/v(\d+\.\d+\.\d(-\w+)?)\.\.\.HEAD\s*`)
 	bottomLinksReplacement := strings.Join([]string{
 		fmt.Sprintf("[Unreleased]: https://github.com/%s/compare/v%s...HEAD", m.repo, m.newVersion),
 		fmt.Sprintf("[%s]: https://github.com/%s/compare/v${1}...v%s", m.newVersion, m.repo, m.newVersion),


### PR DESCRIPTION
We tried to release v5.0.0-alpha2 after having v5.0.0-alpha1 out.
The release automation broke because it didn't find the following line:

```
[Unreleased]: https://github.com/giantswarm/azure-operator/compare/v5.0.0-alpha1...HEAD
```

This PR fixes this problem