### PR TITLE
update github workflows

### DIFF
--- a/.github/workflows/zz_generated.create_release.yaml
+++ b/.github/workflows/zz_generated.create_release.yaml
@@ -14,7 +14,7 @@ on:
 jobs:
   debug_info:
     name: Debug info
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - name: Print github context JSON
         run: |
@@ -23,9 +23,10 @@ jobs:
           EOF
   gather_facts:
     name: Gather facts
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     outputs:
       project_go_path: ${{ steps.get_project_go_path.outputs.path }}
+      ref_version: ${{ steps.ref_version.outputs.refversion }}
       version: ${{ steps.get_version.outputs.version }}
     steps:
       - name: Get version
@@ -34,13 +35,13 @@ jobs:
           title="$(echo "${{ github.event.head_commit.message }}" | head -n 1 -)"
           # Matches strings like:
           #
-          #   - "release v1.2.3"
-          #   - "release v1.2.3-r4"
-          #   - "release v1.2.3 (#56)"
-          #   - "release v1.2.3-r4 (#56)"
+          #   - "Release v1.2.3"
+          #   - "Release v1.2.3-r4"
+          #   - "Release v1.2.3 (#56)"
+          #   - "Release v1.2.3-r4 (#56)"
           #
           # And outputs version part (1.2.3).
-          if echo $title | grep -qE '^release v[0-9]+\.[0-9]+\.[0-9]+([.-][^ .-][^ ]*)?( \(#[0-9]+\))?$' ; then
+          if echo $title | grep -iqE '^Release v[0-9]+\.[0-9]+\.[0-9]+([.-][^ .-][^ ]*)?( \(#[0-9]+\))?$' ; then
             version=$(echo $title | cut -d ' ' -f 2)
           fi
           version="${version#v}" # Strip "v" prefix.
@@ -59,63 +60,41 @@ jobs:
           fi
           echo "path=\"$path\""
           echo "::set-output name=path::${path}"
-  install_semver:
-    name: Install semver
-    runs-on: ubuntu-18.04
-    env:
-      BINARY: "semver"
-      URL: "https://raw.githubusercontent.com/fsaintjacques/semver-tool/3.0.0/src/semver"
-    steps:
-      - name: Key
-        id: key
+      - name: Check if reference version
+        id: ref_version
         run: |
-          cache_dir="/opt/cache"
-          cache_key="install-${BINARY}-${URL}"
-          echo "::set-output name=binary::${BINARY}"
-          echo "::set-output name=cache_dir::${cache_dir}"
-          echo "::set-output name=cache_key::${cache_key}"
-          echo "::set-output name=url::${URL}"
-      - name: Cache
-        id: cache
-        uses: actions/cache@v1
-        with:
-          key: "${{ steps.key.outputs.cache_key }}"
-          path: "${{ steps.key.outputs.cache_dir }}"
-      - name: Download
-        if: ${{ steps.cache.outputs.cache-hit != 'true' }}
-        run: |
-          # TODO check hash
-          binary="${{ steps.key.outputs.binary }}"
-          cache_dir="${{ steps.key.outputs.cache_dir }}"
-          url="${{ steps.key.outputs.url }}"
-          mkdir $cache_dir
-          curl -fsSLo $cache_dir/$binary $url
-          chmod +x $cache_dir/$binary
-      - name: Smoke test
-        run: |
-          ${{ steps.key.outputs.cache_dir }}/${{ steps.key.outputs.binary }} --version
-      - name: Upload artifact
-        uses: actions/upload-artifact@v1
-        with:
-          name: "${{ steps.key.outputs.binary }}"
-          path: "${{ steps.key.outputs.cache_dir }}/${{ steps.key.outputs.binary }}"
+          title="$(echo "${{ github.event.head_commit.message }}" | head -n 1 -)"
+          if echo $title | grep -qE '^release v[0-9]+\.[0-9]+\.[0-9]+([.-][^ .-][^ ]*)?( \(#[0-9]+\))?$' ; then
+            version=$(echo $title | cut -d ' ' -f 2)
+          fi
+          version=$(echo $title | cut -d ' ' -f 2)
+          version="${version#v}" # Strip "v" prefix.
+          refversion=false
+          if [[ "${version}" =~ ^[0-9]+.[0-9]+.[0-9]+-[0-9]+$ ]]; then
+            refversion=true
+          fi
+          echo "refversion =\"$refversion\""
+          echo "::set-output name=refversion::$refversion"
   update_project_go:
     name: Update project.go
-    runs-on: ubuntu-18.04
-    if: ${{ needs.gather_facts.outputs.version != '' && needs.gather_facts.outputs.project_go_path != ''}}
+    runs-on: ubuntu-20.04
+    if: ${{ needs.gather_facts.outputs.version != '' && needs.gather_facts.outputs.project_go_path != '' && needs.gather_facts.outputs.ref_version != 'true' }}
     needs:
       - gather_facts
-      - install_semver
     steps:
-      - name: Download semver artifact to /opt/bin
-        uses: actions/download-artifact@v2
+      - name: Install architect
+        uses: giantswarm/install-binary-action@v1.0.0
         with:
-          name: semver
-          path: /opt/bin
-      - name: Prepare /opt/bin
-        run: |
-          chmod +x /opt/bin/*
-          echo "::add-path::/opt/bin"
+          binary: "architect"
+          version: "3.0.5"
+      - name: Install semver
+        uses: giantswarm/install-binary-action@v1.0.0
+        with:
+          binary: "semver"
+          version: "3.0.0"
+          download_url: "https://github.com/fsaintjacques/${binary}-tool/archive/${version}.tar.gz"
+          tarball_binary_path: "*/src/${binary}"
+          smoke_test: "${binary} --version"
       - name: Checkout code
         uses: actions/checkout@v2
       - name: Update project.go
@@ -158,7 +137,7 @@ jobs:
           hub pull-request -f  -m "${{ env.title }}" -b ${{ env.base }} -h ${{ env.branch }} -r ${{ github.actor }}
   create_release:
     name: Create release
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     needs:
       - gather_facts
     if: ${{ needs.gather_facts.outputs.version }}
@@ -170,7 +149,7 @@ jobs:
         with:
           ref: ${{ github.sha }}
       - name: Ensure correct version in project.go
-        if: ${{ needs.gather_facts.outputs.project_go_path != ''}}
+        if: ${{ needs.gather_facts.outputs.project_go_path != '' && needs.gather_facts.outputs.ref_version != 'true' }}
         run: |
           file="${{ needs.gather_facts.outputs.project_go_path }}"
           version="${{ needs.gather_facts.outputs.version }}"
@@ -195,23 +174,21 @@ jobs:
           release_name: "v${{ needs.gather_facts.outputs.version }}"
   create-release-branch:
     name: Create release branch
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     needs:
       - gather_facts
-      - install_semver
     if: ${{ needs.gather_facts.outputs.version }}
     steps:
-      - name: Download semver artifact to /opt/bin
-        uses: actions/download-artifact@v2
+      - name: Install semver
+        uses: giantswarm/install-binary-action@v1.0.0
         with:
-          name: semver
-          path: /opt/bin
-      - name: Prepare /opt/bin
-        run: |
-          chmod +x /opt/bin/*
-          echo "::add-path::/opt/bin"
-      - uses: actions/checkout@v2
-        name: Check out the repository
+          binary: "semver"
+          version: "3.0.0"
+          download_url: "https://github.com/fsaintjacques/${binary}-tool/archive/${version}.tar.gz"
+          tarball_binary_path: "*/src/${binary}"
+          smoke_test: "${binary} --version"
+      - name: Check out the repository
+        uses: actions/checkout@v2
         with:
           fetch-depth: 0  # Clone the whole history, not just the most recent commit.
       - name: Fetch all tags and branches
@@ -249,47 +226,9 @@ jobs:
           git branch $release_branch HEAD^
           git push origin $release_branch
 
-  install_architect:
-    name: Install architect
-    runs-on: ubuntu-18.04
-    env:
-      BINARY: "architect"
-      DIR: "/opt/cache"
-      IMAGE: "quay.io/giantswarm/architect"
-      IMAGE_PATH: "/usr/bin/architect"
-      VERSION: "1.2.0"
-    outputs:
-      cache_key: "${{ steps.get_cache_key.outputs.cache_key }}"
-    steps:
-      - name: Get cache key
-        id: get_cache_key
-        run: |
-          cache_key="install-${{ env.BINARY }}-${{ env.VERSION }}"
-          echo "::set-output name=cache_key::${cache_key}"
-      - name: Cache
-        id: cache
-        uses: actions/cache@v1
-        with:
-          key: "${{ steps.get_cache_key.outputs.cache_key }}"
-          path: "${{ env.DIR }}"
-      - name: Download
-        if: ${{ steps.cache.outputs.cache-hit != 'true' }}
-        run: |
-          mkdir -p ${{ env.DIR }}
-          docker container create --name tmp ${{ env.IMAGE }}:${{ env.VERSION }}
-          docker cp tmp:${{ env.IMAGE_PATH }} ${{ env.DIR }}/${{ env.BINARY }}
-          docker container rm tmp
-      - name: Smoke test
-        run: |
-          ${{ env.DIR }}/${{ env.BINARY }} version
-      - name: Upload artifact
-        uses: actions/upload-artifact@v2
-        with:
-          name: "${{ env.BINARY }}"
-          path: "${{ env.DIR }}/${{ env.BINARY }}"
   create_and_upload_build_artifacts:
     name: Create and upload build artifacts
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         platform:
@@ -303,29 +242,14 @@ jobs:
     needs:
       - create_release
       - gather_facts
-      - install_architect
     steps:
-      - name: Cache
-        id: cache
-        uses: actions/cache@v1
+      - name: Install architect
+        uses: giantswarm/install-binary-action@v1.0.0
         with:
-          key: "${{ needs.install_architect.outputs.cache_key }}"
-          path: /opt/bin
-      - name: Download architect artifact to /opt/bin
-        if: ${{ steps.cache.outputs.cache-hit != 'true' }}
-        uses: actions/download-artifact@v2
-        with:
-          name: architect
-          path: /opt/bin
-      - name: Prepare /opt/bin
-        run: |
-          chmod +x /opt/bin/*
-          echo "::add-path::/opt/bin"
-      - name: Print architect version
-        run: |
-          architect version
+          binary: "architect"
+          version: "3.0.5"
       - name: Set up Go ${{ env.GO_VERSION }}
-        uses: actions/setup-go@v1
+        uses: actions/setup-go@v2.1.3
         with:
           go-version: ${{ env.GO_VERSION }}
       - name: Checkout code
@@ -339,7 +263,6 @@ jobs:
         env:
           FILE_NAME: ${{ github.event.repository.name }}-${{ env.TAG }}-${{ matrix.platform }}-amd64.tar.gz
         with:
-          path: ${{ env.ARTIFACT_DIR }}
           upload_url: ${{ needs.create_release.outputs.upload_url }}
           asset_path: ${{ env.ARTIFACT_DIR }}/${{ env.FILE_NAME }}
           asset_name: ${{ env.FILE_NAME }}

--- a/.github/workflows/zz_generated.create_release_pr.yaml
+++ b/.github/workflows/zz_generated.create_release_pr.yaml
@@ -14,7 +14,7 @@ on:
 jobs:
   debug_info:
     name: Debug info
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - name: Print github context JSON
         run: |
@@ -23,109 +23,50 @@ jobs:
           EOF
   gather_facts:
     name: Gather facts
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     outputs:
-      unchanged: ${{ steps.get_unchanged.outputs.unchanged }}
-      base: ${{ steps.get_base.outputs.base }}
-      version: ${{ steps.get_version.outputs.version }}
+      base: ${{ steps.gather_facts.outputs.base }}
+      skip: ${{ steps.pr_exists.outputs.skip }}
+      version: ${{ steps.gather_facts.outputs.version }}
     steps:
-      - name: Get base
-        id: get_base
+      - name: Gather facts
+        id: gather_facts
         run: |
-          base="$(echo ${{ github.event.ref }} | cut -d '#' -f 1)"
-          echo "base=\"$base\""
-          echo "::set-output name=base::${base}"
-      - name: Get version
-        id: get_version
-        run: |
-          version="$(echo ${{ github.event.ref }} | cut -d '#' -f 3)"
+          head="${{ github.event.ref }}"
+          head="${head#refs/heads/}" # Strip "refs/heads/" prefix.
+          base="$(echo $head | cut -d '#' -f 1)"
+          base="${base#refs/heads/}" # Strip "refs/heads/" prefix.
+          version="$(echo $head | cut -d '#' -f 3)"
           version="${version#v}" # Strip "v" prefix.
-          echo "version=\"$version\""
+          echo "base=\"$base\" head=\"$head\" version=\"$version\""
+          echo "::set-output name=base::${base}"
+          echo "::set-output name=head::${head}"
           echo "::set-output name=version::${version}"
-      - name: Checkout base code
-        uses: actions/checkout@v2
-        with:
-          ref: ${{ steps.get_base.outputs.base }}
-      - name: Get unchanged
-        id: get_unchanged
+      - name: Check if PR exists
+        id: pr_exists
         env:
-          sha: ${{ github.sha }}
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         run: |
-          base_head=$(git rev-parse HEAD)
-          echo "base_head=\"$base_head\""
-          unchanged="false"
-          if [[ "$base_head" == "${{ env.sha }}" ]] ; then
-            unchanged="true"
+          if gh pr view --repo ${{ github.repository }} ${{ github.event.ref }} ; then
+            echo "::warning::Release PR already exists"
+            echo "::set-output name=skip::true"
+          else
+            echo "::set-output name=skip::false"
           fi
-          echo "unchanged=\"$unchanged\""
-          echo "::set-output name=unchanged::${unchanged}"
-  install_architect:
-    name: Install architect
-    runs-on: ubuntu-18.04
-    env:
-      BINARY: "architect"
-      DIR: "/opt/cache"
-      IMAGE: "quay.io/giantswarm/architect"
-      IMAGE_PATH: "/usr/bin/architect"
-      VERSION: "1.2.0"
-    outputs:
-      cache_key: "${{ steps.get_cache_key.outputs.cache_key }}"
-    steps:
-      - name: Get cache key
-        id: get_cache_key
-        run: |
-          cache_key="install-${{ env.BINARY }}-${{ env.VERSION }}"
-          echo "::set-output name=cache_key::${cache_key}"
-      - name: Cache
-        id: cache
-        uses: actions/cache@v1
-        with:
-          key: "${{ steps.get_cache_key.outputs.cache_key }}"
-          path: "${{ env.DIR }}"
-      - name: Download
-        if: ${{ steps.cache.outputs.cache-hit != 'true' }}
-        run: |
-          mkdir -p ${{ env.DIR }}
-          docker container create --name tmp ${{ env.IMAGE }}:${{ env.VERSION }}
-          docker cp tmp:${{ env.IMAGE_PATH }} ${{ env.DIR }}/${{ env.BINARY }}
-          docker container rm tmp
-      - name: Smoke test
-        run: |
-          ${{ env.DIR }}/${{ env.BINARY }} version
-      - name: Upload artifact
-        uses: actions/upload-artifact@v1
-        with:
-          name: "${{ env.BINARY }}"
-          path: "${{ env.DIR }}/${{ env.BINARY }}"
   create_release_pr:
     name: Create release PR
-    runs-on: ubuntu-18.04
-    if: ${{ needs.gather_facts.outputs.unchanged == 'true' }}
+    runs-on: ubuntu-20.04
     needs:
       - gather_facts
-      - install_architect
+    if: ${{ needs.gather_facts.outputs.skip != 'true' }}
     env:
       architect_flags: "--organisation ${{ github.repository_owner }} --project ${{ github.event.repository.name }}"
     steps:
-      - name: Cache
-        id: cache
-        uses: actions/cache@v1
+      - name: Install architect
+        uses: giantswarm/install-binary-action@v1.0.0
         with:
-          key: "${{ needs.install_architect.outputs.cache_key }}"
-          path: /opt/bin
-      - name: Download architect artifact to /opt/bin
-        if: ${{ steps.cache.outputs.cache-hit != 'true' }}
-        uses: actions/download-artifact@v2
-        with:
-          name: architect
-          path: /opt/bin
-      - name: Prepare /opt/bin
-        run: |
-          chmod +x /opt/bin/*
-          echo "::add-path::/opt/bin"
-      - name: Print architect version
-        run: |
-          architect version ${{ env.architect_flags }}
+          binary: "architect"
+          version: "3.0.5"
       - name: Checkout code
         uses: actions/checkout@v2
       - name: Prepare release changes
@@ -138,7 +79,7 @@ jobs:
           git config --local user.email "action@github.com"
           git config --local user.name "github-actions"
           git add -A
-          git commit -m "release v${{ env.version }}"
+          git commit -m "Release v${{ env.version }}"
       - name: Push changes
         env:
           remote_repo: "https://${{ github.actor }}:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git"
@@ -150,4 +91,4 @@ jobs:
           base: "${{ needs.gather_facts.outputs.base }}"
           version: "${{ needs.gather_facts.outputs.version }}"
         run: |
-          hub pull-request -f  -m "release v${{ env.version }}" -a ${{ github.actor }} -b ${{ env.base }} -h ${{ github.event.ref }}
+          hub pull-request -f  -m "Release v${{ env.version }}" -a ${{ github.actor }} -b ${{ env.base }} -h ${{ github.event.ref }}

--- a/.github/workflows/zz_generated.gitleaks.yaml
+++ b/.github/workflows/zz_generated.gitleaks.yaml
@@ -1,0 +1,17 @@
+# DO NOT EDIT. Generated with:
+#
+#    devctl gen workflows
+#
+name: gitleaks
+
+on: [push,pull_request]
+
+jobs:
+  gitleaks:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: '0'
+    - name: gitleaks-action
+      uses: zricethezav/gitleaks-action@v1.1.4


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/14557

This PR resulted from : `devctl gen workflows --flavour cli`

Fixes the following errors in github actions

```
Error: Unable to process command '::add-path::/opt/bin' successfully.
Error: The `add-path` command is disabled. Please upgrade to using Environment Files or opt into unsecure command execution by setting the `ACTIONS_ALLOW_UNSECURE_COMMANDS` environment variable to `true`. For more information see: https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/
```