### PR TITLE
Add kubebuilder to the image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Added kubebuilder to the image to be able to run integration tests based on
+  controller-runtime `envtest`.
+
 ## [3.4.0] - 2021-03-17
 
 ### Changed

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,7 @@ ENV GOPATH /go
 ENV PATH $GOPATH/bin:/usr/local/go/bin:$PATH
 
 ARG HELM_VERSION=v3.5.3
+ARG KUBEBUILDER_VERSION=2.3.1
 ARG GOLANGCI_LINT_VERSION=v1.38.0
 ARG NANCY_VERSION=v1.0.17
 
@@ -37,6 +38,9 @@ RUN apk add --no-cache \
         openssh-client &&\
         curl -SL https://get.helm.sh/helm-${HELM_VERSION}-linux-amd64.tar.gz | \
             tar -C /usr/bin --strip-components 1 -xvzf - linux-amd64/helm && \
+        curl -sSfL https://go.kubebuilder.io/dl/${KUBEBUILDER_VERSION}/$(go env GOOS)/$(go env GOARCH) | \
+            tar -xz -C /tmp/ && \
+            mv /tmp/kubebuilder_${KUBEBUILDER_VERSION}_$(go env GOOS)_$(go env GOARCH) /usr/local/kubebuilder && \
         curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | \
             sh -s -- -b $GOPATH/bin ${GOLANGCI_LINT_VERSION} && \
         curl -sSL -o /usr/bin/nancy https://github.com/sonatype-nexus-community/nancy/releases/download/${NANCY_VERSION}/nancy-${NANCY_VERSION}-linux-amd64 && \


### PR DESCRIPTION
This allows running integration tests based on controller-runtime
[envtest](https://pkg.go.dev/sigs.k8s.io/controller-runtime/pkg/envtest).