### PR TITLE
Copy chart schema from app-build-suite

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,8 @@ FROM quay.io/giantswarm/helm-chart-testing:v3.3.1 AS ct
 
 RUN pip freeze > /helm-chart-testing-py-requirements.txt
 
+FROM quay.io/giantswarm/app-build-suite:0.2.2 AS abs
+
 FROM quay.io/giantswarm/golang:1.16.2-alpine3.13 AS golang
 
 FROM quay.io/giantswarm/conftest:v0.21.0 AS conftest
@@ -15,7 +17,7 @@ COPY --from=golang /usr/local/go /usr/local/go
 # Copy files needed for Helm Chart testing
 COPY --from=ct /helm-chart-testing-py-requirements.txt /helm-chart-testing-py-requirements.txt
 COPY --from=ct /usr/local/bin/ct /usr/local/bin/ct
-COPY --from=ct /etc/ct/chart_schema.yaml /etc/ct/chart_schema.yaml
+COPY --from=abs /abs/resources/ct_schemas/gs_metadata_chart_schema.yaml /etc/ct/chart_schema.yaml
 COPY --from=ct /etc/ct/lintconf.yaml /etc/ct/lintconf.yaml
 
 COPY --from=conftest /usr/local/bin/conftest /usr/local/bin/conftest


### PR DESCRIPTION
This PR changes the container image to copy the chart schema from app-build-suite.

Background:

For the app metadata story https://github.com/giantswarm/giantswarm/issues/10926 we've added some additional keys to `Chart.yaml` files of some components. (like `restrictions`, `compatibleProviders`). While `app-build-suite` makes `ct lint` aware of these new keys, standard chart testing does not know about the new keys schemas and makes CI runs fail for projects not using `app-build-suite` for packaging helm charts.

Check https://app.circleci.com/pipelines/github/giantswarm/chart-operator/1684/workflows/b300b87f-c7e5-40d7-a3c7-219fc57a31a3/jobs/16000 for reference failing CI run.

Fixed CI run using architect from this branch https://app.circleci.com/pipelines/github/giantswarm/chart-operator/1685/workflows/be33ce5a-da4e-42c2-a363-06224a2b5f13/jobs/16005

Ping @QuentinBisson who ran into this first