### PR TITLE
Add helm diff plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `diff` helm plugin `v3.1.3`.
+
 ## [5.2.0] - 2021-09-10
 
 ### Changed

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,7 @@ ENV GOPATH /go
 ENV PATH $GOPATH/bin:/usr/local/go/bin:$PATH
 
 ARG HELM_VERSION=v3.5.3
+ARG HELM_DIFF_VERSION=v3.1.3
 ARG KUBEBUILDER_VERSION=3.1.0
 ARG GOLANGCI_LINT_VERSION=v1.42.1
 ARG NANCY_VERSION=v1.0.17
@@ -41,6 +42,7 @@ RUN apk add --no-cache \
         yq &&\
         curl -SL https://get.helm.sh/helm-${HELM_VERSION}-linux-amd64.tar.gz | \
             tar -C /usr/bin --strip-components 1 -xvzf - linux-amd64/helm && \
+        helm plugin install https://github.com/databus23/helm-diff --version ${HELM_DIFF_VERSION} && \
         curl -sSfL -o /usr/local/kubebuilder https://github.com/kubernetes-sigs/kubebuilder/releases/download/v${KUBEBUILDER_VERSION}/kubebuilder_$(go env GOOS)_$(go env GOARCH) && \
         curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | \
             sh -s -- -b $GOPATH/bin ${GOLANGCI_LINT_VERSION} && \


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/18975

Adding `helm diff` plugin in order to be able to detect duplicate resources in charts.

e.g.

```
$ helm diff upgrade --debug --dry-run --detailed-exitcode --no-color prometheus-rules ./helm/prometheus-rules -f ./helm/prometheus-rules/ci/default-values.yaml
Executing helm version
Executing helm template prometheus-rules ./helm/prometheus-rules --namespace monitoring --values ./helm/prometheus-rules/ci/default-values.yaml --is-upgrade
2021/09/28 13:19:41 Error: Found duplicate key "monitoring, service-level.rules, PrometheusRule (monitoring.coreos.com)" in manifest
```