### PR TITLE
add kubeval

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `kubeval` version `v0.16.1`.
+
 ## [5.2.0] - 2021-09-10
 
 ### Changed

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,7 @@ ARG HELM_VERSION=v3.5.3
 ARG KUBEBUILDER_VERSION=3.1.0
 ARG GOLANGCI_LINT_VERSION=v1.42.1
 ARG NANCY_VERSION=v1.0.17
+ARG KUBEVAL_VERSION=v0.16.1
 ARG CT_YAMALE_VER=3.0.6
 ARG CT_YAMLLINT_VER=1.26.1
 
@@ -45,7 +46,9 @@ RUN apk add --no-cache \
         curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | \
             sh -s -- -b $GOPATH/bin ${GOLANGCI_LINT_VERSION} && \
         curl -sSL -o /usr/bin/nancy https://github.com/sonatype-nexus-community/nancy/releases/download/${NANCY_VERSION}/nancy-${NANCY_VERSION}-linux-amd64 && \
-        chmod +x /usr/bin/nancy
+            chmod +x /usr/bin/nancy && \
+        curl -sSL https://github.com/instrumenta/kubeval/releases/download/${KUBEVAL_VERSION}/kubeval-$(go env GOOS)-$(go env GOARCH).tar.gz | \
+            tar -C /usr/bin -xvzf - kubeval
 
 # Setup ssh config for github.com
 RUN mkdir ~/.ssh &&\


### PR DESCRIPTION
Towards: giantswarm/giantswarm#18975

Adding [`kubeval`](https://www.kubeval.com/) in order to be able to detect duplicate resources in charts.

e.g.

```
$ helm template test ./helm/prometheus-rules --namespace monitoring --values ./helm/prometheus-rules/ci/default-values.yaml --is-upgrade|./kubeval --ignore-missing-schemas -
WARN - Set to ignore missing schemas
ERR  - prometheus-rules/templates/recording-rules/service-levels.rules.yml: Duplicate 'PrometheusRule' resource 'service-level.rules' in namespace 'monitoring'
```