### PR TITLE
Add update-changelog flag to prepare-release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `--update-changelog` flag to `prepare-release` command to allow disabling changelog update.
+
 ## [5.3.0] - 2021-09-29
 
 ### Added

--- a/cmd/preparerelease/flag.go
+++ b/cmd/preparerelease/flag.go
@@ -1,5 +1,6 @@
 package preparerelease
 
 func init() {
+	Cmd.Flags().Bool("update-changelog", true, "if true, update CHANGELOG.md")
 	Cmd.Flags().String("version", "", "version to be released")
 }

--- a/cmd/preparerelease/runner.go
+++ b/cmd/preparerelease/runner.go
@@ -24,6 +24,11 @@ func runPrepareRelease(cmd *cobra.Command, args []string) error {
 		return microerror.Maskf(executionFailedError, "--version flag can't be empty")
 	}
 
+	updateChangelog := cmd.Flag("update-changelog").Value.String()
+	if updateChangelog != "" && updateChangelog != "true" && updateChangelog != "false" {
+		return microerror.Maskf(executionFailedError, "--update-changelog flag must be true or false")
+	}
+
 	var m *internal.Modifier
 	{
 		c := internal.ModifierConfig{
@@ -38,11 +43,13 @@ func runPrepareRelease(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	err = m.AddReleaseToChangelogMd()
-	if err != nil {
-		return microerror.Mask(err)
+	if updateChangelog != "false" {
+		err = m.AddReleaseToChangelogMd()
+		if err != nil {
+			return microerror.Mask(err)
+		}
+		cmd.Printf("File %#q updated.\n", internal.FileChangelogMd)
 	}
-	cmd.Printf("File %#q updated.\n", internal.FileChangelogMd)
 
 	err = m.UpdateVersionInProjectGo()
 	if internal.IsFileNotFound(err) {

--- a/cmd/preparerelease/runner.go
+++ b/cmd/preparerelease/runner.go
@@ -24,9 +24,9 @@ func runPrepareRelease(cmd *cobra.Command, args []string) error {
 		return microerror.Maskf(executionFailedError, "--version flag can't be empty")
 	}
 
-	updateChangelog := cmd.Flag("update-changelog").Value.String()
-	if updateChangelog != "" && updateChangelog != "true" && updateChangelog != "false" {
-		return microerror.Maskf(executionFailedError, "--update-changelog flag must be true or false")
+	updateChangelog, err := cmd.Flags().GetBool("update-changelog")
+	if err != nil {
+		return microerror.Mask(err)
 	}
 
 	var m *internal.Modifier
@@ -43,7 +43,7 @@ func runPrepareRelease(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	if updateChangelog != "false" {
+	if updateChangelog {
 		err = m.AddReleaseToChangelogMd()
 		if err != nil {
 			return microerror.Mask(err)


### PR DESCRIPTION
Needed for https://github.com/giantswarm/devctl/pull/332

See https://github.com/giantswarm/actions-test/pull/46 for example

The new automation will automatically generate release notes based on commits since the last release. As a result, we can stop editing `CHANGELOG.md` for repositories using this method. This PR makes architect not attempt to update `CHANGELOG.md`. It defaults to false so shouldn't affect any existing users.