### PR TITLE
Update Go to 1.19.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Update Go to 1.19.1.
+- Update Alpine to 3.16.2.
+- Update Go CI linter to 1.49.0.
+
 ## [6.6.0] - 2022-07-11
 
 ### Changed

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,12 +2,12 @@ FROM quay.io/giantswarm/helm-chart-testing:v3.6.0 AS ct
 
 FROM quay.io/giantswarm/app-build-suite:0.2.3 AS abs
 
-FROM quay.io/giantswarm/golang:1.18.1-alpine3.15 AS golang
+FROM quay.io/giantswarm/golang:1.19.1-alpine3.16 AS golang
 
 FROM quay.io/giantswarm/conftest:v0.33.1 AS conftest
 
 # Build Image
-FROM quay.io/giantswarm/alpine:3.14.2
+FROM quay.io/giantswarm/alpine:3.16.2
 
 # Copy go from golang image.
 COPY --from=golang /usr/local/go /usr/local/go
@@ -24,7 +24,7 @@ ENV PATH $GOPATH/bin:/usr/local/go/bin:$PATH
 
 ARG HELM_VERSION=v3.8.1
 ARG KUBEBUILDER_VERSION=3.1.0
-ARG GOLANGCI_LINT_VERSION=v1.46.0
+ARG GOLANGCI_LINT_VERSION=v1.49.0
 ARG NANCY_VERSION=v1.0.37
 ARG KUBEVAL_VERSION=v0.16.1
 ARG CT_YAMALE_VER=3.0.6


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/23916

Also:
- Update Go to 1.19.1.
- Update Alpine to 3.16.2 (used by Go 1.19.1 image).
- Update Go CI linter to 1.49.0 (to get latest linter with the latest go).