### PR TITLE
Bump Go to v1.20.6

### DIFF
--- a/.nancy-ignore
+++ b/.nancy-ignore
@@ -1,14 +1,17 @@
 # The Hashicorp consul /sdk and /api libraries are no longer intended for public use.
 # Excluding them until dependencies move away.
-CVE-2022-29153 until=2023-05-26
-CVE-2022-24687 until=2023-05-26
+CVE-2022-29153 until=2023-08-31
+CVE-2022-24687 until=2023-08-31
 
 # pkg:golang/github.com/caddyserver/caddy@v1.0.3
-CVE-2022-29718 until=2023-05-26
+CVE-2022-29718 until=2023-08-31
 
 # pkg:golang/github.com/lucas-clemente/quic-go@v0.10.2
-CVE-2022-30591 until=2023-05-26
+CVE-2022-30591 until=2023-08-31
 
 # pkg:golang/k8s.io/apiserver@v0.27.0
 # There is no fix yet
-CVE-2020-8561 until=2023-06-01
+CVE-2020-8561 until=2023-08-31
+
+# pkg:golang/google.golang.org/grpc@v1.51.0
+CVE-2023-32731 until=2023-08-31

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Update Go to v1.20.6
+
 ## [6.11.0] - 2023-04-13
 
 ### Changed

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM quay.io/giantswarm/helm-chart-testing:v3.7.1 AS ct
 
 FROM quay.io/giantswarm/app-build-suite:1.1.4 AS abs
 
-FROM quay.io/giantswarm/golang:1.19.6-alpine3.17 AS golang
+FROM quay.io/giantswarm/golang:1.20.6-alpine3.17 AS golang
 
 FROM quay.io/giantswarm/conftest:v0.37.0 AS conftest
 


### PR DESCRIPTION
Blocked by https://github.com/giantswarm/retagger/pull/856 