### PR TITLE
Pre-install jq on the architect image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [6.13.0] - 2023-11-08
+## [6.13.0] - 2023-12-11
+
+- Pre-install jq on the base image
 
 ### Changed
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -39,7 +39,8 @@ RUN apk add --no-cache \
         py-pip \
         openssh-client \
         make \
-        yq &&\
+        yq \
+        jq &&\
         curl -SL https://get.helm.sh/helm-${HELM_VERSION}-linux-amd64.tar.gz | \
             tar -C /usr/bin --strip-components 1 -xvzf - linux-amd64/helm && \
         curl -sSfL -o /usr/local/kubebuilder https://github.com/kubernetes-sigs/kubebuilder/releases/download/v${KUBEBUILDER_VERSION}/kubebuilder_$(go env GOOS)_$(go env GOARCH) && \


### PR DESCRIPTION
I need `jq` in this PR: https://github.com/giantswarm/architect-orb/pull/481