### PR TITLE
Bump golang:1.21.12-alpine3.19

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM gsoci.azurecr.io/giantswarm/helm-chart-testing:v3.11.0 AS ct
 
 FROM gsoci.azurecr.io/giantswarm/app-build-suite:1.2.2 AS abs
 
-FROM gsoci.azurecr.io/giantswarm/golang:1.21.6-alpine3.18 AS golang
+FROM gsoci.azurecr.io/giantswarm/golang:1.21.12-alpine3.19 AS golang
 
 FROM gsoci.azurecr.io/giantswarm/conftest:v0.54.0 AS conftest
 


### PR DESCRIPTION
Towards:
- https://github.com/giantswarm/giantswarm/issues/31374
- https://github.com/giantswarm/giantswarm/issues/31396

Bump `golang:1.21.12-alpine3.19` to fix following critical CVEs:
- CVE-2024-24790