### PR TITLE
Allow renovate to update dependencies in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,12 +22,19 @@ COPY --from=conftest /usr/local/bin/conftest /usr/local/bin/conftest
 ENV GOPATH /go
 ENV PATH $GOPATH/bin:/usr/local/go/bin:$PATH
 
+# renovate: datasource=github-releases depName=helm/helm
 ARG HELM_VERSION=v3.8.1
+# renovate: datasource=github-releases depName=kubernetes-sigs/kubebuilder
 ARG KUBEBUILDER_VERSION=3.1.0
+# renovate: datasource=github-releases depName=golangci/golangci-lint
 ARG GOLANGCI_LINT_VERSION=v1.60.3
+# renovate: datasource=github-releases depName=sonatype-nexus-community/nancy
 ARG NANCY_VERSION=v1.0.46
+# renovate: datasource=github-releases depName=yannh/kubeconform
 ARG KUBECONFORM_VERSION=v0.4.14
+# renovate: datasource=pypi depName=yamale
 ARG CT_YAMALE_VER=3.0.6
+# renovate: datasource=pypi depName=yamllint
 ARG CT_YAMLLINT_VER=1.32.0
 
 RUN apk add --no-cache \

--- a/renovate.json5
+++ b/renovate.json5
@@ -5,4 +5,16 @@
     // Go specific config - https://github.com/giantswarm/renovate-presets/blob/main/lang-go.json5
     "github>giantswarm/renovate-presets:lang-go.json5",
   ],
+  customManagers: [
+    // Detect versions in Dockerfile ARGs
+    {
+      customType: 'regex',
+      fileMatch: ['Dockerfile.*'],
+      matchStrings: [
+        // for the version on the right part, ignoring the left
+        '# renovate: datasource=(?<datasource>.*?) depName=(?<depName>.*?)( versioning=(?<versioning>.*?))?\\sARG [A-Z_]+=(?<currentValue>\\S+)',
+      ],
+      versioningTemplate: '{{#if versioning}}{{{versioning}}}{{else}}semver{{/if}}',
+    },
+  ],
 }


### PR DESCRIPTION
This should let Renovate update the dependency versions set via ARG directives.