### PR TITLE
Fix multi-arch image for arm64

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,8 +19,8 @@ COPY --from=ct /etc/ct/lintconf.yaml /etc/ct/lintconf.yaml
 
 COPY --from=conftest /usr/local/bin/conftest /usr/local/bin/conftest
 
-ENV GOPATH /go
-ENV PATH $GOPATH/bin:/usr/local/go/bin:$PATH
+ENV GOPATH=/go
+ENV PATH=$GOPATH/bin:/usr/local/go/bin:$PATH
 
 # renovate: datasource=github-releases depName=helm/helm
 ARG HELM_VERSION=v3.19.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -74,5 +74,5 @@ RUN rm -f /usr/lib/python3.11/EXTERNALLY-MANAGED
 
 RUN pip install --break-system-packages yamllint==${CT_YAMLLINT_VER} yamale==${CT_YAMALE_VER}
 
-ADD ./architect /usr/bin/architect
+ADD ./architect-${TARGETOS}-${TARGETARCH} /usr/bin/architect
 ENTRYPOINT ["/usr/bin/architect"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,9 @@ COPY --from=conftest /usr/local/bin/conftest /usr/local/bin/conftest
 ENV GOPATH=/go
 ENV PATH=$GOPATH/bin:/usr/local/go/bin:$PATH
 
+ARG TARGETARCH
+ARG TARGETOS
+
 # renovate: datasource=github-releases depName=helm/helm
 ARG HELM_VERSION=v3.19.0
 # renovate: datasource=github-releases depName=kubernetes-sigs/kubebuilder

--- a/Dockerfile
+++ b/Dockerfile
@@ -54,10 +54,10 @@ RUN apk add --no-cache \
   openssh-client \
   make \
   yq &&\
-  curl -SL https://get.helm.sh/helm-${HELM_VERSION}-linux-amd64.tar.gz | \
-  tar -C /usr/bin --strip-components 1 -xvzf - linux-amd64/helm && \
-  curl -sSfL -o /usr/local/kubebuilder https://github.com/kubernetes-sigs/kubebuilder/releases/download/v${KUBEBUILDER_VERSION}/kubebuilder_$(go env GOOS)_$(go env GOARCH) && \
-  curl -sSL -o /usr/bin/nancy https://github.com/sonatype-nexus-community/nancy/releases/download/${NANCY_VERSION}/nancy-${NANCY_VERSION}-linux-amd64 && \
+  curl -SL https://get.helm.sh/helm-${HELM_VERSION}-${TARGETOS}-${TARGETARCH}.tar.gz | \
+  tar -C /usr/bin --strip-components 1 -xvzf - ${TARGETOS}-${TARGETARCH}/helm && \
+  curl -sSfL -o /usr/local/kubebuilder https://github.com/kubernetes-sigs/kubebuilder/releases/download/v${KUBEBUILDER_VERSION}/kubebuilder_${TARGETOS}_${TARGETARCH} && \
+  curl -sSL -o /usr/bin/nancy https://github.com/sonatype-nexus-community/nancy/releases/download/${NANCY_VERSION}/nancy-${NANCY_VERSION}-${TARGETOS}-${TARGETARCH} && \
   chmod +x /usr/bin/nancy && \
   go install github.com/yannh/kubeconform/cmd/kubeconform@${KUBECONFORM_VERSION}
 


### PR DESCRIPTION
Follow-up to https://github.com/giantswarm/architect/pull/1212

Previously the binary included in the arm64 architecture part of the image was not suited for arm.

This PR aims to build an image where the binary is actually an ARM one.

Test:

<img width="1684" height="573" alt="image" src="https://github.com/user-attachments/assets/63c670b1-f53d-48f6-bcee-dbd7a0e4eee8" />

