### PR TITLE
Tidy Dockerfile: redundant apk update, no-op xtrace, fragile chmod

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Drop redundant `apk update` from the Alpine package install — `apk add --no-cache` already fetches a fresh index.
+- Move xtrace into the `SHELL` directive (`bash -xc`) so subsequent `RUN` commands are actually traced; the previous `RUN set -o xtrace` only set the option for a one-shot shell that exited immediately.
+- Replace `chmod 600 ~/.ssh/*` with an explicit list of `known_hosts` and `config` so the step doesn't break if `~/.ssh/` ever ends up empty.
+
 ## [7.4.0] - 2026-02-12
 
 ### Changed

--- a/Dockerfile
+++ b/Dockerfile
@@ -47,7 +47,7 @@ ARG CT_YAMALE_VER=6.1.0
 # renovate: datasource=pypi depName=yamllint
 ARG CT_YAMLLINT_VER=1.38.0
 
-RUN apk update && apk add --no-cache --no-scripts \
+RUN apk add --no-cache --no-scripts \
   bash \
   ca-certificates \
   curl \
@@ -61,10 +61,7 @@ RUN apk update && apk add --no-cache --no-scripts \
   wget \
   yq
 
-SHELL ["/bin/bash", "-c"]
-
-# Print command
-RUN set -o xtrace
+SHELL ["/bin/bash", "-xc"]
 
 # Install Helm
 RUN curl -sSL https://get.helm.sh/helm-${HELM_VERSION}-linux-${TARGETARCH}.tar.gz | \
@@ -88,7 +85,7 @@ RUN mkdir ~/.ssh && \
   chmod 700 ~/.ssh && \
   ssh-keyscan github.com >> ~/.ssh/known_hosts &&\
   printf "Host github.com\n IdentitiesOnly yes\n IdentityFile ~/.ssh/id_rsa\n" >> ~/.ssh/config && \
-  chmod 600 ~/.ssh/*
+  chmod 600 ~/.ssh/known_hosts ~/.ssh/config
 
 # Allow installing python modules in the global context.
 # See https://peps.python.org/pep-0668/


### PR DESCRIPTION
Three trivial Dockerfile cleanups, no behavior change to the image content.

### Changed

- **`apk update`** removed from the apk install line. `apk add --no-cache` already fetches a fresh index in memory and skips writing the on-disk cache, so the explicit update is redundant and leaves cache files in the resulting layer. Documented Alpine practice.
- **`SHELL ["/bin/bash", "-xc"]`** replaces the separate `RUN set -o xtrace` line. The previous form only set xtrace for a one-shot shell that exited immediately, so none of the subsequent `RUN` commands were actually being traced. Moving the flag into `SHELL` makes tracing cover every `RUN` after that line, matching the original intent of the `# Print command` comment.
- **`chmod 600 ~/.ssh/known_hosts ~/.ssh/config`** instead of `chmod 600 ~/.ssh/*`. The glob works today (both files exist) but breaks if `~/.ssh/` is ever empty. Explicit list makes the step robust.

The `--platform=$BUILDPLATFORM` builder-stage refactor (real cross-build perf win for `go install kubeconform`) is a separate, larger PR I'll open next.