### PR TITLE
Bake cosign and hadolint into the architect image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Drop redundant `apk update` from the Alpine package install — `apk add --no-cache` already fetches a fresh index.
 - Move xtrace into the `SHELL` directive (`bash -xc`) so subsequent `RUN` commands are actually traced; the previous `RUN set -o xtrace` only set the option for a one-shot shell that exited immediately.
 - Replace `chmod 600 ~/.ssh/*` with an explicit list of `known_hosts` and `config` so the step doesn't break if `~/.ssh/` ever ends up empty.
+- Cross-compile `kubeconform` in a `--platform=$BUILDPLATFORM` builder stage instead of `RUN go install` in the target-arch final image. Avoids running the Go toolchain under QEMU when buildx targets a non-host architecture, materially speeding up the arm64 build leg.
 
 ## [7.4.0] - 2026-02-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Drop redundant `apk update` from the Alpine package install — `apk add --no-cache` already fetches a fresh index.
+- Move xtrace into the `SHELL` directive (`bash -xc`) so subsequent `RUN` commands are actually traced; the previous `RUN set -o xtrace` only set the option for a one-shot shell that exited immediately.
+- Replace `chmod 600 ~/.ssh/*` with an explicit list of `known_hosts` and `config` so the step doesn't break if `~/.ssh/` ever ends up empty.
+
 ## [7.4.0] - 2026-02-12
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Drop redundant `apk update` from the Alpine package install — `apk add --no-cache` already fetches a fresh index.
 - Move xtrace into the `SHELL` directive (`bash -xc`) so subsequent `RUN` commands are actually traced; the previous `RUN set -o xtrace` only set the option for a one-shot shell that exited immediately.
 - Replace `chmod 600 ~/.ssh/*` with an explicit list of `known_hosts` and `config` so the step doesn't break if `~/.ssh/` ever ends up empty.
-- Cross-compile `kubeconform` in a `--platform=$BUILDPLATFORM` builder stage instead of `RUN go install` in the target-arch final image. Avoids running the Go toolchain under QEMU when buildx targets a non-host architecture, materially speeding up the arm64 build leg.
+- Install `kubeconform` from its upstream pre-built release tarball instead of compiling from source with `go install`. Upstream ships `kubeconform-linux-amd64.tar.gz` / `kubeconform-linux-arm64.tar.gz` already. Eliminates the Go toolchain run during the image build (no QEMU emulation under buildx cross-arch, no source dependency tree to resolve).
 
 ## [7.4.0] - 2026-02-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Install `cosign` (sigstore) in the image. Used by `architect-orb` for keyless image/chart/binary signing, so the orb no longer has to download cosign per-run.
+- Install `hadolint` in the image — Dockerfile linter. Enables a `hadolint` command in `architect-orb` without per-run downloads.
+
 ### Changed
 
 - Drop redundant `apk update` from the Alpine package install — `apk add --no-cache` already fetches a fresh index.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Extract `gh-token` version into a renovate-tracked `GH_TOKEN_VERSION` ARG, matching every other binary in the image.
 - Drop redundant `apk update` from the Alpine package install — `apk add --no-cache` already fetches a fresh index.
 - Move xtrace into the `SHELL` directive (`bash -xc`) so subsequent `RUN` commands are actually traced; the previous `RUN set -o xtrace` only set the option for a one-shot shell that exited immediately.
 - Replace `chmod 600 ~/.ssh/*` with an explicit list of `known_hosts` and `config` so the step doesn't break if `~/.ssh/` ever ends up empty.

--- a/Dockerfile
+++ b/Dockerfile
@@ -39,6 +39,9 @@ ARG COSIGN_VERSION=v3.0.3
 # renovate: datasource=github-releases depName=hadolint/hadolint
 ARG HADOLINT_VERSION=v2.14.0
 
+# renovate: datasource=github-releases depName=Link-/gh-token
+ARG GH_TOKEN_VERSION=v2.0.6
+
 # The `kubeconform` tool is used only when Helm Chart is build and published
 # with the `architect` executor, which for majority of the project is not the
 # case anymore, for they are build and published with the ABS.
@@ -99,7 +102,7 @@ RUN curl -sSL "https://github.com/yannh/kubeconform/releases/download/${KUBECONF
   tar -C /usr/bin -xzf - kubeconform
 
 # Install gh-token that can generate temporary tokens to authenticate towards Github and use it to access the API
-RUN wget --no-verbose https://github.com/Link-/gh-token/releases/download/v2.0.6/linux-${TARGETARCH} -O /usr/bin/gh-token && chmod 700 /usr/bin/gh-token
+RUN wget --no-verbose https://github.com/Link-/gh-token/releases/download/${GH_TOKEN_VERSION}/linux-${TARGETARCH} -O /usr/bin/gh-token && chmod 700 /usr/bin/gh-token
 
 # Setup ssh config for github.com
 RUN mkdir ~/.ssh && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,6 +33,12 @@ ARG KUBEBUILDER_VERSION=4.14.0
 # renovate: datasource=github-releases depName=sonatype-nexus-community/nancy
 ARG NANCY_VERSION=v1.2.0
 
+# renovate: datasource=github-releases depName=sigstore/cosign
+ARG COSIGN_VERSION=v3.0.3
+
+# renovate: datasource=github-releases depName=hadolint/hadolint
+ARG HADOLINT_VERSION=v2.14.0
+
 # The `kubeconform` tool is used only when Helm Chart is build and published
 # with the `architect` executor, which for majority of the project is not the
 # case anymore, for they are build and published with the ABS.
@@ -73,6 +79,20 @@ RUN curl -sSfL -o /usr/local/kubebuilder https://github.com/kubernetes-sigs/kube
 # Install nancy
 RUN curl -sSL -o /usr/bin/nancy https://github.com/sonatype-nexus-community/nancy/releases/download/${NANCY_VERSION}/nancy-${NANCY_VERSION}-linux-${TARGETARCH} && \
   chmod +x /usr/bin/nancy
+
+# Install cosign (used by architect-orb for keyless image/chart/binary signing).
+RUN curl -sSL -o /usr/bin/cosign https://github.com/sigstore/cosign/releases/download/${COSIGN_VERSION}/cosign-linux-${TARGETARCH} && \
+  chmod +x /usr/bin/cosign
+
+# Install hadolint (Dockerfile linter). Upstream asset names use Linux-x86_64 /
+# Linux-arm64 instead of linux-amd64 / linux-arm64, so translate.
+RUN case "${TARGETARCH}" in \
+      amd64) hadolint_arch=x86_64 ;; \
+      arm64) hadolint_arch=arm64 ;; \
+      *) echo "Unsupported TARGETARCH=${TARGETARCH} for hadolint"; exit 1 ;; \
+    esac && \
+    curl -sSL -o /usr/bin/hadolint "https://github.com/hadolint/hadolint/releases/download/${HADOLINT_VERSION}/hadolint-Linux-${hadolint_arch}" && \
+    chmod +x /usr/bin/hadolint
 
 # Install kubeconform from the upstream pre-built release tarball.
 RUN curl -sSL "https://github.com/yannh/kubeconform/releases/download/${KUBECONFORM_VERSION}/kubeconform-linux-${TARGETARCH}.tar.gz" | \

--- a/Dockerfile
+++ b/Dockerfile
@@ -47,7 +47,7 @@ ARG CT_YAMALE_VER=6.1.0
 # renovate: datasource=pypi depName=yamllint
 ARG CT_YAMLLINT_VER=1.38.0
 
-RUN apk update && apk add --no-cache --no-scripts \
+RUN apk add --no-cache --no-scripts \
   bash \
   ca-certificates \
   curl \
@@ -61,10 +61,7 @@ RUN apk update && apk add --no-cache --no-scripts \
   wget \
   yq
 
-SHELL ["/bin/bash", "-c"]
-
-# Print command
-RUN set -o xtrace
+SHELL ["/bin/bash", "-xc"]
 
 # Install Helm
 RUN curl -sSL https://get.helm.sh/helm-${HELM_VERSION}-linux-${TARGETARCH}.tar.gz | \
@@ -88,7 +85,7 @@ RUN mkdir ~/.ssh && \
   chmod 700 ~/.ssh && \
   ssh-keyscan github.com >> ~/.ssh/known_hosts &&\
   printf "Host github.com\n IdentitiesOnly yes\n IdentityFile ~/.ssh/id_rsa\n" >> ~/.ssh/config && \
-  chmod 600 ~/.ssh/*
+  chmod 600 ~/.ssh/known_hosts ~/.ssh/config
 
 # Allow installing python modules in the global context.
 # See https://peps.python.org/pep-0668/

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,26 +6,6 @@ FROM gsoci.azurecr.io/giantswarm/golang:1.26.3-alpine3.23 AS golang
 
 FROM gsoci.azurecr.io/giantswarm/conftest:v0.68.2 AS conftest
 
-# Cross-compile kubeconform on the build host instead of emulating the target
-# arch under QEMU when buildx targets a non-host platform.
-FROM --platform=$BUILDPLATFORM gsoci.azurecr.io/giantswarm/golang:1.26.2-alpine3.23 AS kubeconform-builder
-ARG TARGETOS
-ARG TARGETARCH
-# renovate: datasource=github-releases depName=yannh/kubeconform
-ARG KUBECONFORM_VERSION=v0.7.0
-ENV GOPATH=/go
-RUN CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH \
-    go install github.com/yannh/kubeconform/cmd/kubeconform@${KUBECONFORM_VERSION}
-# `go install` puts the binary at /go/bin/<name> when GOOS/GOARCH match the
-# host, and at /go/bin/${GOOS}_${GOARCH}/<name> when cross-compiling.
-# Normalize so the final stage has a single known source path.
-RUN mkdir -p /out && \
-    if [ -f "/go/bin/kubeconform" ]; then \
-      cp /go/bin/kubeconform /out/kubeconform; \
-    else \
-      cp "/go/bin/${TARGETOS}_${TARGETARCH}/kubeconform" /out/kubeconform; \
-    fi
-
 # Build Image
 FROM gsoci.azurecr.io/giantswarm/alpine:3.23.4
 
@@ -52,6 +32,12 @@ ARG KUBEBUILDER_VERSION=4.14.0
 
 # renovate: datasource=github-releases depName=sonatype-nexus-community/nancy
 ARG NANCY_VERSION=v1.2.0
+
+# The `kubeconform` tool is used only when Helm Chart is build and published
+# with the `architect` executor, which for majority of the project is not the
+# case anymore, for they are build and published with the ABS.
+# renovate: datasource=github-releases depName=yannh/kubeconform
+ARG KUBECONFORM_VERSION=v0.7.0
 
 # The `yamale` tool does not seem to be used anymore, it is still here just in case
 # some CI magic somewhere still relies on it.
@@ -88,10 +74,9 @@ RUN curl -sSfL -o /usr/local/kubebuilder https://github.com/kubernetes-sigs/kube
 RUN curl -sSL -o /usr/bin/nancy https://github.com/sonatype-nexus-community/nancy/releases/download/${NANCY_VERSION}/nancy-${NANCY_VERSION}-linux-${TARGETARCH} && \
   chmod +x /usr/bin/nancy
 
-# Install kubeconform (pre-built on the host arch in the kubeconform-builder stage above).
-# Used only when Helm charts are built and published with the `architect` executor,
-# which most projects no longer do (they use ABS instead).
-COPY --from=kubeconform-builder /out/kubeconform /go/bin/kubeconform
+# Install kubeconform from the upstream pre-built release tarball.
+RUN curl -sSL "https://github.com/yannh/kubeconform/releases/download/${KUBECONFORM_VERSION}/kubeconform-linux-${TARGETARCH}.tar.gz" | \
+  tar -C /usr/bin -xzf - kubeconform
 
 # Install gh-token that can generate temporary tokens to authenticate towards Github and use it to access the API
 RUN wget --no-verbose https://github.com/Link-/gh-token/releases/download/v2.0.6/linux-${TARGETARCH} -O /usr/bin/gh-token && chmod 700 /usr/bin/gh-token

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,26 @@ FROM gsoci.azurecr.io/giantswarm/golang:1.26.3-alpine3.23 AS golang
 
 FROM gsoci.azurecr.io/giantswarm/conftest:v0.68.2 AS conftest
 
+# Cross-compile kubeconform on the build host instead of emulating the target
+# arch under QEMU when buildx targets a non-host platform.
+FROM --platform=$BUILDPLATFORM gsoci.azurecr.io/giantswarm/golang:1.26.2-alpine3.23 AS kubeconform-builder
+ARG TARGETOS
+ARG TARGETARCH
+# renovate: datasource=github-releases depName=yannh/kubeconform
+ARG KUBECONFORM_VERSION=v0.7.0
+ENV GOPATH=/go
+RUN CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH \
+    go install github.com/yannh/kubeconform/cmd/kubeconform@${KUBECONFORM_VERSION}
+# `go install` puts the binary at /go/bin/<name> when GOOS/GOARCH match the
+# host, and at /go/bin/${GOOS}_${GOARCH}/<name> when cross-compiling.
+# Normalize so the final stage has a single known source path.
+RUN mkdir -p /out && \
+    if [ -f "/go/bin/kubeconform" ]; then \
+      cp /go/bin/kubeconform /out/kubeconform; \
+    else \
+      cp "/go/bin/${TARGETOS}_${TARGETARCH}/kubeconform" /out/kubeconform; \
+    fi
+
 # Build Image
 FROM gsoci.azurecr.io/giantswarm/alpine:3.23.4
 
@@ -32,12 +52,6 @@ ARG KUBEBUILDER_VERSION=4.14.0
 
 # renovate: datasource=github-releases depName=sonatype-nexus-community/nancy
 ARG NANCY_VERSION=v1.2.0
-
-# The `kubeconform` tool is used only when Helm Chart is build and published
-# with the `architect` executor, which for majority of the project is not the
-# case anymore, for they are build and published with the ABS.
-# renovate: datasource=github-releases depName=yannh/kubeconform
-ARG KUBECONFORM_VERSION=v0.7.0
 
 # The `yamale` tool does not seem to be used anymore, it is still here just in case
 # some CI magic somewhere still relies on it.
@@ -74,8 +88,10 @@ RUN curl -sSfL -o /usr/local/kubebuilder https://github.com/kubernetes-sigs/kube
 RUN curl -sSL -o /usr/bin/nancy https://github.com/sonatype-nexus-community/nancy/releases/download/${NANCY_VERSION}/nancy-${NANCY_VERSION}-linux-${TARGETARCH} && \
   chmod +x /usr/bin/nancy
 
-# Install kubeconform
-RUN go install github.com/yannh/kubeconform/cmd/kubeconform@${KUBECONFORM_VERSION}
+# Install kubeconform (pre-built on the host arch in the kubeconform-builder stage above).
+# Used only when Helm charts are built and published with the `architect` executor,
+# which most projects no longer do (they use ABS instead).
+COPY --from=kubeconform-builder /out/kubeconform /go/bin/kubeconform
 
 # Install gh-token that can generate temporary tokens to authenticate towards Github and use it to access the API
 RUN wget --no-verbose https://github.com/Link-/gh-token/releases/download/v2.0.6/linux-${TARGETARCH} -O /usr/bin/gh-token && chmod 700 /usr/bin/gh-token


### PR DESCRIPTION
Adds two static binaries to the architect runtime image:

- **cosign v3.0.3** — sigstore signing/verification tool. Used by `architect-orb` for keyless image/chart signing today (downloaded per-run); will also be used for binary signing in `architect-orb` v9.3. Baking it in removes ~10 lines of repeated install logic from each orb consumer site and saves a network round-trip per build.
- **hadolint v2.14.0** — Dockerfile linter. Enables a future `hadolint` command in `architect-orb` without per-run downloads.

Both are renovate-tracked. hadolint's upstream asset names use `Linux-x86_64` / `Linux-arm64` (not `linux-amd64` / `linux-arm64`), so the install step translates `TARGETARCH`.

Also extracts `gh-token` to a renovate-tracked `GH_TOKEN_VERSION` ARG — it was the last binary in the image whose version was hardcoded into the URL.

Independent of `architect-orb` PRs — the orb's cosign install step is guarded with `command -v cosign >/dev/null || install_cosign` (coming in orb v9.3), so it stays correct both before and after this image lands.