### PR TITLE
feat!: switch from gitrepo to gitsemver

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,6 +42,9 @@ ARG HADOLINT_VERSION=v2.14.0
 # renovate: datasource=github-releases depName=Link-/gh-token
 ARG GH_TOKEN_VERSION=v2.0.10
 
+# renovate: datasource=github-releases depName=giantswarm/gitsemver
+ARG GITSEMVER_VERSION=v1.0.1
+
 # The `kubeconform` tool is used only when Helm Chart is build and published
 # with the `architect` executor, which for majority of the project is not the
 # case anymore, for they are build and published with the ABS.
@@ -103,6 +106,10 @@ RUN curl -sSL "https://github.com/yannh/kubeconform/releases/download/${KUBECONF
 
 # Install gh-token that can generate temporary tokens to authenticate towards Github and use it to access the API
 RUN wget --no-verbose https://github.com/Link-/gh-token/releases/download/${GH_TOKEN_VERSION}/linux-${TARGETARCH} -O /usr/bin/gh-token && chmod 700 /usr/bin/gh-token
+
+# Install gitsemver CLI for use in CI scripts running inside the container.
+RUN curl -sSL "https://github.com/giantswarm/gitsemver/releases/download/${GITSEMVER_VERSION}/gitsemver-${GITSEMVER_VERSION}-linux-${TARGETARCH}.tar.gz" | \
+    tar -C /usr/bin -xzf - gitsemver && gitsemver version
 
 # Setup ssh config for github.com
 RUN mkdir ~/.ssh && \

--- a/cmd/helm/template/runner.go
+++ b/cmd/helm/template/runner.go
@@ -10,7 +10,7 @@ import (
 	"path/filepath"
 	"strconv"
 
-	"github.com/giantswarm/gitrepo/pkg/gitrepo"
+	"github.com/giantswarm/gitsemver/pkg/gitsemver"
 	"github.com/giantswarm/microerror"
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
@@ -46,7 +46,7 @@ func runTemplateError(cmd *cobra.Command, args []string) (err error) {
 	var appVersion string
 	skipAppVersionCheck := false
 	{
-		dir, err := gitrepo.TopLevel(ctx, ".")
+		dir, err := gitsemver.TopLevel(ctx, ".")
 		if err != nil {
 			return microerror.Mask(err)
 		}

--- a/cmd/helm/template/runner_test.go
+++ b/cmd/helm/template/runner_test.go
@@ -6,7 +6,7 @@ import (
 	"strconv"
 	"testing"
 
-	"github.com/giantswarm/gitrepo/pkg/gitrepo"
+	"github.com/giantswarm/gitsemver/pkg/gitsemver"
 	"github.com/giantswarm/microerror"
 
 	"github.com/giantswarm/architect/pkg/project"
@@ -18,7 +18,7 @@ func TestGetProjectVersion(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
-	architectGitTopLevelDir, err := gitrepo.TopLevel(ctx, ".")
+	architectGitTopLevelDir, err := gitsemver.TopLevel(ctx, ".")
 	if err != nil {
 		t.Fatalf("err = %#q, want %#v", microerror.JSON(err), nil)
 	}

--- a/cmd/hook/pre_run_e.go
+++ b/cmd/hook/pre_run_e.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/pkg/errors"
 
-	"github.com/giantswarm/gitrepo/pkg/gitrepo"
+	"github.com/giantswarm/gitsemver/pkg/gitsemver"
 	"github.com/giantswarm/microerror"
 	"github.com/spf13/cobra"
 )
@@ -15,19 +15,19 @@ func PreRunE(cmd *cobra.Command, args []string) error {
 
 	var err error
 
-	var repo *gitrepo.Repo
+	var repo *gitsemver.Repo
 	{
 		cwd := cmd.Flag("working-directory").Value.String()
-		dir, err := gitrepo.TopLevel(ctx, cwd)
+		dir, err := gitsemver.TopLevel(ctx, cwd)
 		if err != nil {
 			return microerror.Mask(err)
 		}
 
-		c := gitrepo.Config{
+		c := gitsemver.Config{
 			Dir: dir,
 		}
 
-		repo, err = gitrepo.New(c)
+		repo, err = gitsemver.New(c)
 		if err != nil {
 			return microerror.Mask(err)
 		}
@@ -39,7 +39,7 @@ func PreRunE(cmd *cobra.Command, args []string) error {
 	}
 
 	defaultTag, err := repo.HeadTag(ctx)
-	if errors.Is(err, &gitrepo.ReferenceNotFoundError{}) {
+	if errors.Is(err, &gitsemver.ReferenceNotFoundError{}) {
 		defaultTag = ""
 	} else if err != nil {
 		return microerror.Mask(err)

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.25.0
 
 require (
 	github.com/giantswarm/app/v8 v8.1.1
-	github.com/giantswarm/gitrepo v0.3.5
+	github.com/giantswarm/gitsemver v1.0.1
 	github.com/giantswarm/microerror v0.4.1
 	github.com/google/go-cmp v0.7.0
 	github.com/pkg/errors v0.9.1
@@ -26,7 +26,7 @@ require (
 	github.com/go-errors/errors v1.5.1 // indirect
 	github.com/go-git/gcfg v1.5.1-0.20230307220236-3a3c6141e376 // indirect
 	github.com/go-git/go-billy/v5 v5.9.0 // indirect
-	github.com/go-git/go-git/v5 v5.19.0 // indirect
+	github.com/go-git/go-git/v5 v5.19.1 // indirect
 	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/golang/groupcache v0.0.0-20241129210726-2c02b8208cf8 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -28,8 +28,8 @@ github.com/giantswarm/apiextensions-application v0.6.2 h1:XL86OrpprWl5Wp38EUvUXt
 github.com/giantswarm/apiextensions-application v0.6.2/go.mod h1:8ylqSmDSzFblCppRQTFo8v9s/F6MX6RTusVVoDDfWso=
 github.com/giantswarm/app/v8 v8.1.1 h1:kS9Ma++OBVyODEzYiGA6JcYNOCxuAxu17VpYneIzyIA=
 github.com/giantswarm/app/v8 v8.1.1/go.mod h1:TUwvutQSqcs43FUsoSHlcIS87aqhYyJ2uunbf5Hbb1E=
-github.com/giantswarm/gitrepo v0.3.5 h1:e2ziPSxkJLTxe+x/l8l2O1oA42C5sFUjgbX4zOW5pgw=
-github.com/giantswarm/gitrepo v0.3.5/go.mod h1:fOhUqVyRXyZdJcW+Fxr2t/SrBkG1XFc1WceDOG4iZyE=
+github.com/giantswarm/gitsemver v1.0.1 h1:JABO9VkOqMVqhW6ooWKm9JFpIdtLXJoQrdoac0rJUDE=
+github.com/giantswarm/gitsemver v1.0.1/go.mod h1:d3URbgfWBk3nKAepQ+49i4To9TeEDiJ4wKKRfDvjP0A=
 github.com/giantswarm/k8smetadata v0.25.0 h1:6mKmmm4xHPuBvxDMAkIhU5oj6KJkJSaR2s5esIsnHs4=
 github.com/giantswarm/k8smetadata v0.25.0/go.mod h1:QiQAyaZnwco1U0lENLF0Kp4bSN4dIPwIlHWEvUo3ES8=
 github.com/giantswarm/microerror v0.4.1 h1:WMiD7HQASoUA9lZzPlPK+erCEOJ0uT4cyo18VfCXHD0=
@@ -44,8 +44,8 @@ github.com/go-git/go-billy/v5 v5.9.0 h1:jItGXszUDRtR/AlferWPTMN4j38BQ88XnXKbilmm
 github.com/go-git/go-billy/v5 v5.9.0/go.mod h1:jCnQMLj9eUgGU7+ludSTYoZL/GGmii14RxKFj7ROgHw=
 github.com/go-git/go-git-fixtures/v4 v4.3.2-0.20231010084843-55a94097c399 h1:eMje31YglSBqCdIqdhKBW8lokaMrL3uTkpGYlE2OOT4=
 github.com/go-git/go-git-fixtures/v4 v4.3.2-0.20231010084843-55a94097c399/go.mod h1:1OCfN199q1Jm3HZlxleg+Dw/mwps2Wbk9frAWm+4FII=
-github.com/go-git/go-git/v5 v5.19.0 h1:+WkVUQZSy/F1Gb13udrMKjIM2PrzsNfDKFSfo5tkMtc=
-github.com/go-git/go-git/v5 v5.19.0/go.mod h1:Pb1v0c7/g8aGQJwx9Us09W85yGoyvSwuhEGMH7zjDKQ=
+github.com/go-git/go-git/v5 v5.19.1 h1:nX27AnaU43/K5bKktKwgBmR9lawoYVe1Ckg0rgzzN00=
+github.com/go-git/go-git/v5 v5.19.1/go.mod h1:Pb1v0c7/g8aGQJwx9Us09W85yGoyvSwuhEGMH7zjDKQ=
 github.com/go-logr/logr v1.4.3 h1:CjnDlHq8ikf6E492q6eKboGOC0T8CDaOvkHCIg8idEI=
 github.com/go-logr/logr v1.4.3/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=
 github.com/golang/groupcache v0.0.0-20241129210726-2c02b8208cf8 h1:f+oWsMOmNPc8JmEHVZIycC7hBoQxHH9pNKQORJNozsQ=


### PR DESCRIPTION
Merge after `architect-orb` v9 release.

Switch architect to the new gitsemver lib/tool.