### PR TITLE
feat: install syft and oras CLIs in the architect container image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Added
+
+- Install `syft` in the docker image
+
 ## [8.0.0] - 2026-06-01
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Added
 
 - Install `syft` in the docker image
+- Install `oras` in the docker image
 
 ## [8.0.0] - 2026-06-01
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -45,6 +45,9 @@ ARG GH_TOKEN_VERSION=v2.0.10
 # renovate: datasource=github-releases depName=giantswarm/gitsemver
 ARG GITSEMVER_VERSION=v1.1.2
 
+# renovate: datasource=github-releases depName=anchore/syft
+ARG SYFT_VERSION=v1.44.0
+
 # The `kubeconform` tool is used only when Helm Chart is build and published
 # with the `architect` executor, which for majority of the project is not the
 # case anymore, for they are build and published with the ABS.
@@ -110,6 +113,12 @@ RUN wget --no-verbose https://github.com/Link-/gh-token/releases/download/${GH_T
 # Install gitsemver CLI for use in CI scripts running inside the container.
 RUN curl -sSL "https://github.com/giantswarm/gitsemver/releases/download/${GITSEMVER_VERSION}/gitsemver-${GITSEMVER_VERSION}-linux-${TARGETARCH}.tar.gz" | \
     tar -C /usr/bin --strip-components 1 -xzf - gitsemver-${GITSEMVER_VERSION}-linux-${TARGETARCH}/gitsemver
+
+# Install syft (SBOM generator). Upstream release tarballs use the version
+# without the leading `v` in the asset filename, while the download path uses
+# the `v`-prefixed tag.
+RUN curl -sSL "https://github.com/anchore/syft/releases/download/${SYFT_VERSION}/syft_${SYFT_VERSION#v}_linux_${TARGETARCH}.tar.gz" | \
+    tar -C /usr/bin -xzf - syft
 
 # Setup ssh config for github.com
 RUN mkdir ~/.ssh && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -48,6 +48,9 @@ ARG GITSEMVER_VERSION=v1.1.2
 # renovate: datasource=github-releases depName=anchore/syft
 ARG SYFT_VERSION=v1.44.0
 
+# renovate: datasource=github-releases depName=oras-project/oras
+ARG ORAS_VERSION=v1.3.2
+
 # The `kubeconform` tool is used only when Helm Chart is build and published
 # with the `architect` executor, which for majority of the project is not the
 # case anymore, for they are build and published with the ABS.
@@ -119,6 +122,11 @@ RUN curl -sSL "https://github.com/giantswarm/gitsemver/releases/download/${GITSE
 # the `v`-prefixed tag.
 RUN curl -sSL "https://github.com/anchore/syft/releases/download/${SYFT_VERSION}/syft_${SYFT_VERSION#v}_linux_${TARGETARCH}.tar.gz" | \
     tar -C /usr/bin -xzf - syft
+
+# Install oras (OCI registry client). Like syft, the asset filename uses the
+# version without the leading `v` while the download path uses the tag.
+RUN curl -sSL "https://github.com/oras-project/oras/releases/download/${ORAS_VERSION}/oras_${ORAS_VERSION#v}_linux_${TARGETARCH}.tar.gz" | \
+    tar -C /usr/bin -xzf - oras
 
 # Setup ssh config for github.com
 RUN mkdir ~/.ssh && \


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/36746

## What

Makes the [`syft`](https://github.com/anchore/syft) SBOM generator CLI available in the architect container image (the one used in CircleCI).

## Changes

- **`Dockerfile`**
  - Added a renovate-annotated `ARG SYFT_VERSION=v1.44.0` so the version auto-updates, matching the existing tooling convention.
  - Added an install step that downloads the release tarball into `/usr/bin` (on `PATH`), reusing the same `curl | tar` pattern as `kubeconform`/`gitsemver` and respecting `TARGETARCH` for both `linux/amd64` and `linux/arm64`.
  - syft's asset filenames use the bare version (`syft_1.44.0_linux_amd64.tar.gz`) while the download path uses the `v`-prefixed tag, so the filename uses `${SYFT_VERSION#v}` to strip the leading `v`. Verified against the v1.44.0 release assets.
- **`CHANGELOG.md`**: added an `### Added` note under `[Unreleased]`.

## Notes

I couldn't build/run the image to smoke-test `syft version` here, since this is the CI build image and there's no Docker build available in this environment. The asset URL pattern and arch handling are verified against the upstream release.

https://claude.ai/code/session_01S9ZNHLoLpHKPk92jydeLUV

---
_Generated by [Claude Code](https://claude.ai/code/session_01S9ZNHLoLpHKPk92jydeLUV)_