### PR TITLE
feat(ci): release darwin and windows binaries

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,6 +6,7 @@ workflows:
   go-build:
     jobs:
     - architect/go-build:
+        context: architect
         binary: architect
         architectures: "linux/amd64,linux/arm64,darwin/amd64,darwin/arm64,windows/amd64,windows/arm64"
         # Needed to trigger job also on git tag.

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,23 +1,19 @@
 version: 2.1
 orbs:
-  architect: giantswarm/architect@8.0.2
+  architect: giantswarm/architect@9.1.0
 
 workflows:
   go-build:
     jobs:
     - architect/go-build:
         binary: architect
-        matrix:
-          parameters:
-            architecture:
-              - linux/amd64
-              - linux/arm64
+        architectures: "linux/amd64,linux/arm64,darwin/amd64,darwin/arm64,windows/amd64,windows/arm64"
         # Needed to trigger job also on git tag.
         filters:
           tags:
             only: /^v.*/
 
-    - architect/push-to-registries-multiarch:
+    - architect/push-to-registries:
         context: architect
         name: push-to-registries
         requires:
@@ -33,3 +29,15 @@ workflows:
             ignore:
               - main
               - master
+
+    - architect/upload-release-assets:
+        context: architect
+        name: upload-release-assets
+        binary: architect
+        requires:
+          - architect/go-build
+        filters:
+          tags:
+            only: /^v.*/
+          branches:
+            ignore: /.*/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Changed
+
+- Release binaries now include darwin/amd64, darwin/arm64, windows/amd64, and windows/arm64 alongside the existing linux targets. Windows binaries are named `architect-windows-<arch>.exe`.
+
 ## [8.1.0] - 2026-06-02
 
 ### Added


### PR DESCRIPTION
## What

- `go-build`: replaces the `matrix.parameters.architecture` approach with the `architectures` parameter, adding `darwin/amd64`, `darwin/arm64`, `windows/amd64`, `windows/arm64` alongside the existing linux targets.
- `push-to-registries`: replaces the removed `push-to-registries-multiarch` job with `push-to-registries` (the unified job in orb 9.x); keeps `registries-data` and pins `platforms: "linux/amd64,linux/arm64"`.
- `upload-release-assets`: new job; uploads binaries and cosign `.bundle` files to the GitHub Release on tags.
- Bumps architect orb 8.0.2 to 9.1.0. The `push-to-registries-multiarch` job was removed in 9.x; `push-to-registries` now handles both single and multi-arch builds via the same job.

Same pattern as giantswarm/muster#796.