### PR TITLE
chore: remove duplicate renovate config

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -1,22 +1,7 @@
 {
   extends: [
-    // Base config - https://github.com/giantswarm/renovate-presets/blob/main/default.json5
-    'github>giantswarm/renovate-presets:default.json5',
-    // Go specific config - https://github.com/giantswarm/renovate-presets/blob/main/lang-go.json5
+    // Go specific config (also extends default.json5)
+    // https://github.com/giantswarm/renovate-presets/blob/main/lang-go.json5
     'github>giantswarm/renovate-presets:lang-go.json5',
-  ],
-  customManagers: [
-    {
-      // Detect versions in Dockerfile ARGs
-      customType: 'regex',
-      managerFilePatterns: [
-        '/Dockerfile.*/',
-      ],
-      matchStrings: [
-        // for the version on the right part, ignoring the left
-        '# renovate: datasource=(?<datasource>.*?) depName=(?<depName>.*?)( versioning=(?<versioning>.*?))?\\sARG [A-Z_]+=(?<currentValue>\\S+)',
-      ],
-      versioningTemplate: '{{#if versioning}}{{{versioning}}}{{else}}semver{{/if}}',
-    },
   ],
 }


### PR DESCRIPTION
The current configuration results in renovate triple-detecting the dependencies.

This updates it to correctly use the default renovate presets.

Example:
<img width="1131" height="1651" alt="image" src="https://github.com/user-attachments/assets/ca7f51e1-4ae8-4ddd-8b6b-0e5cae271e25" />
